### PR TITLE
Feature/fix missing lakes

### DIFF
--- a/src/API/public/map_styles.json
+++ b/src/API/public/map_styles.json
@@ -17,12 +17,14 @@
     },
     {
       "name": "lakes_reservoirs",
-      "fillColor":[150,180,190,1]
+      "fillColor":[150,180,190,1],
+      "zIndex":1
     },
     {
       "name": "rivers_lakes",
       "strokeColor":[150,180,190,1],
-      "strokeWidth":1
+      "strokeWidth":1,
+      "fillColor":[150,180,190,1]
     }
   ]
 }

--- a/src/TileServer/getMapData.sh
+++ b/src/TileServer/getMapData.sh
@@ -24,9 +24,7 @@ get_naturalEarthData physical ne_10m_rivers_lake_centerlines rivers_lakes
 get_naturalEarthData physical ne_10m_lakes lakes_reservoirs
 
 cd ./data/geojson
-tippecanoe -zg -Z5 -o rivers-and-lakes.mbtiles --coalesce-densest-as-needed --extend-zooms-if-still-dropping rivers_lakes.json lakes_reservoirs.json --force
-tippecanoe -zg -o land-and-oceans.mbtiles --coalesce-densest-as-needed --extend-zooms-if-still-dropping countries.json land.json oceans.json --force
-tile-join -o world.mbtiles rivers-and-lakes.mbtiles land-and-oceans.mbtiles  --force
+tippecanoe -zg -o world.mbtiles --extend-zooms-if-still-dropping countries.json land.json oceans.json rivers_lakes.json lakes_reservoirs.json --force
 cd ../../
 
 cleanup_data_geojson_json countries


### PR DESCRIPTION
Updated the map styles to bring lakes to the top.
Compressed the map building command so rivers and lakes are shown at all levels.
Now that the config for map styles has been separated from the repo on the production environment we will need to remember to copy over the new version during deployment.