### PR TITLE
Solving unnoticed error

### DIFF
--- a/src/API/src/db/shared/entities/dataset.entity.ts
+++ b/src/API/src/db/shared/entities/dataset.entity.ts
@@ -20,15 +20,16 @@ export class Dataset extends BaseEntity {
   UpdatedAt: Date;
 
   @Column('varchar', { nullable: true, array: true, default: [] })
-  @Field({ nullable: true })
+  //@Field({ nullable: true })
   ReviewedBy: string[];
+  
 
   @Column({ nullable: true, type: 'timestamptz', array: true, default: [] })
   @Field(() => Date, { nullable: true })
   ReviewedAt: Date[];
 
   @Column('varchar', { nullable: true, array: true, default: [] })
-  @Field({ nullable: true })
+  //@Field({ nullable: true })
   ApprovedBy: string[];
 
   @Column({ nullable: true, type: 'timestamptz', array: true, default: [] })


### PR DESCRIPTION
An issue arised that I did not notice before the merge. The `@Field` decorator seems to be rejected by the column:` ReviewedBy` and column `ApprovedBy` when set as string arrays. In this recent push, I've commented out the `@Field `decorator; the error disappears. I realize the decorator is needed in order for the property to reflect in the schema. Is there an alternative or suggestion on how to go about this?