### PR TITLE
Fixed the nginx config to proxy MAP resources

### DIFF
--- a/src/Docker/nginx/default.conf
+++ b/src/Docker/nginx/default.conf
@@ -47,6 +47,11 @@ server {
         proxy_pass http://tileserver:80;
     }
 
+    location /map-wms {
+        rewrite ^/map-wms(.*)$ /geoserver/Interventions/wms$1 break;
+        proxy_pass https://data.malariaatlas.org;
+    }
+
     # You may need this to prevent return 404 recursion.
     location = /404.html {
         internal;


### PR DESCRIPTION
Currently the map image download doesn't work if you turn on a MAP overlay because the HTML5 canvas is marked as tainted (due to being cross-origin). This fix allows us to proxy MAP resources through our system and make it appear as if it's coming from the same domain. The overlay config will need to be updated on the server after this PR is deployed.

Links to #436 
