### PR TITLE
Increasing the proxy buffer sizes to deal with Auth0 headers

### DIFF
--- a/src/Docker/nginx/default.conf
+++ b/src/Docker/nginx/default.conf
@@ -13,6 +13,11 @@ server {
     # Frontend
     location / {
         proxy_pass http://ui:3000/; # same name as network alias
+
+        # dealing with proxy header too big from Auth0
+        proxy_buffer_size          128k;
+        proxy_buffers              4 256k;
+        proxy_busy_buffers_size    256k;
     }
 
     # Analytics


### PR DESCRIPTION
Attempting to increase the buffer size in the nginx proxy

Links to #{insert issues this PR links to}
