### PR TITLE
Fixed the layer transformation script so the scaling is applied before the color map

### DIFF
--- a/src/API/transformGeotiff.sh
+++ b/src/API/transformGeotiff.sh
@@ -1,9 +1,11 @@
 echo "Running transformation script for $1$2"
 set -e
 cp $1$2.tif /tmp/$2.tif
-gdaldem color-relief /tmp/$2.tif ./colormap.txt /tmp/$2_colorized.tif -alpha || exit 1
-gdal_translate -scale 0 $4 0 1 -of MBTiles -ot Byte /tmp/$2_colorized.tif /tmp/$2.mbtiles || exit 1
+gdal_translate -scale 0 $4 0 1 /tmp/$2.tif /tmp/$2_scaled.tif || exit 1
+gdaldem color-relief /tmp/$2_scaled.tif ./colormap.txt /tmp/$2_colorized.tif -alpha || exit 1
+gdal_translate -scale 0 1 0 1 -of MBTiles -ot Byte /tmp/$2_colorized.tif /tmp/$2.mbtiles || exit 1
 gdaladdo -r nearest /tmp/$2.mbtiles 2 4 8 16 32 || exit 1
 mv /tmp/$2.mbtiles $3$2.mbtiles || exit 1
 rm /tmp/$2.tif || exit 1
 rm /tmp/$2_colorized.tif || exit 1
+rm /tmp/$2_scaled.tif || exit 1


### PR DESCRIPTION
There is a bug in the overlay transformation script if an overlay with a max value different from 1 is used. I've now updated the script to apply the scaling before applying the colour map.

Here's what the updated An. stephensi map now looks like with the fix:
![image](https://user-images.githubusercontent.com/34268284/220571213-994eca52-23c1-4566-b4c8-56a07b954cb1.png)

