### PR TITLE
Feature/species overlays floating panel

### DIFF
--- a/src/UI/components/map/layers/OverlayPanel.tsx
+++ b/src/UI/components/map/layers/OverlayPanel.tsx
@@ -1,0 +1,43 @@
+import { Box } from "@mui/material";
+import { useAppSelector } from "../../../state/hooks";
+import { SpeciesOverlaysPanel } from "./SpeciesOverlayModal";
+import { IROverlaysPanel } from "./irOverlayModal";
+
+export const OverlayPanel: React.FC = () => {
+    const isVectorPanelVisible = useAppSelector((s) => s.map.map_drawer.open);
+
+    return (
+        <Box
+            sx={{
+                position: 'relative',
+                width: 0,
+                overflow: 'visible',
+                display: 'flex',
+                backgroundColor: 'red'
+            }}
+            >
+            <Box
+                sx={{
+                flex: 1,
+                position: 'absolute',
+                boxSizing: 'border-box',
+                top: 0,
+                left: 0,
+                zIndex: 1300,
+                display: 'flex',
+                flexDirection: 'column',
+                overflowX: 'hidden',
+                overflowY: 'auto',
+                height: '100%',
+                margin: isVectorPanelVisible ? '0 8px 8px 8px' : '0',
+                width: isVectorPanelVisible ? 'calc(100% - 16px)' : '100%',
+                minHeight: '100%',
+                minWidth: 'fit-content',
+            }}
+            >
+                <SpeciesOverlaysPanel />
+                <IROverlaysPanel />
+            </Box>
+        </Box>
+    )
+}

--- a/src/UI/components/map/layers/OverlayPanel.tsx
+++ b/src/UI/components/map/layers/OverlayPanel.tsx
@@ -1,43 +1,43 @@
-import { Box } from "@mui/material";
-import { useAppSelector } from "../../../state/hooks";
-import { SpeciesOverlaysPanel } from "./SpeciesOverlayModal";
-import { IROverlaysPanel } from "./irOverlayModal";
+import { Box } from '@mui/material';
+import { useAppSelector } from '../../../state/hooks';
+import { SpeciesOverlaysPanel } from './SpeciesOverlayModal';
+import { IROverlaysPanel } from './irOverlayModal';
 
 export const OverlayPanel: React.FC = () => {
-    const isVectorPanelVisible = useAppSelector((s) => s.map.map_drawer.open);
+  const isVectorPanelVisible = useAppSelector((s) => s.map.map_drawer.open);
 
-    return (
-        <Box
-            sx={{
-                position: 'relative',
-                width: 0,
-                overflow: 'visible',
-                display: 'flex',
-                backgroundColor: 'red'
-            }}
-            >
-            <Box
-                sx={{
-                flex: 1,
-                position: 'absolute',
-                boxSizing: 'border-box',
-                top: 0,
-                left: 0,
-                zIndex: 1300,
-                display: 'flex',
-                flexDirection: 'column',
-                overflowX: 'hidden',
-                overflowY: 'auto',
-                height: '100%',
-                margin: isVectorPanelVisible ? '0 8px 8px 8px' : '0',
-                width: isVectorPanelVisible ? 'calc(100% - 16px)' : '100%',
-                minHeight: '100%',
-                minWidth: 'fit-content',
-            }}
-            >
-                <SpeciesOverlaysPanel />
-                <IROverlaysPanel />
-            </Box>
-        </Box>
-    )
-}
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        width: 0,
+        overflow: 'visible',
+        display: 'flex',
+        backgroundColor: 'red',
+      }}
+    >
+      <Box
+        sx={{
+          flex: 1,
+          position: 'absolute',
+          boxSizing: 'border-box',
+          top: 0,
+          left: 0,
+          zIndex: 1300,
+          display: 'flex',
+          flexDirection: 'column',
+          overflowX: 'hidden',
+          overflowY: 'auto',
+          height: '100%',
+          margin: isVectorPanelVisible ? '0 8px 8px 8px' : '0',
+          width: isVectorPanelVisible ? 'calc(100% - 16px)' : '100%',
+          minHeight: '100%',
+          minWidth: 'fit-content',
+        }}
+      >
+        <SpeciesOverlaysPanel />
+        <IROverlaysPanel />
+      </Box>
+    </Box>
+  );
+};

--- a/src/UI/components/map/layers/SpeciesOverlayList.tsx
+++ b/src/UI/components/map/layers/SpeciesOverlayList.tsx
@@ -31,9 +31,13 @@ export const SpeciesOverlayList: React.FC<SpeciesOverlayListProps> = ({
   const WMTS_WORKSPACE = WMTSWorkspacesEnum.SPECIES;
 
   const drawerOpen = useAppSelector((s) => s.map.map_drawer.open);
-  const wmtsLayers = useAppSelector((s) => s.map.wmtsLayers.filter((layer) => layer.workspace === WMTS_WORKSPACE));
+  const wmtsLayers = useAppSelector((s) =>
+    s.map.wmtsLayers.filter((layer) => layer.workspace === WMTS_WORKSPACE)
+  );
   const wmtsStatus = useAppSelector((s) => s.map.wmtsStatus);
-  const wmtsWorkspaceLoaded = useAppSelector((s) => s.map.wmtsWorkspaces.includes(WMTS_WORKSPACE));
+  const wmtsWorkspaceLoaded = useAppSelector((s) =>
+    s.map.wmtsWorkspaces.includes(WMTS_WORKSPACE)
+  );
 
   // Lazy-load: only fetch when the section is first opened
   useEffect(() => {
@@ -81,7 +85,9 @@ export const SpeciesOverlayList: React.FC<SpeciesOverlayListProps> = ({
           {wmtsStatus === 'failed' && (
             <ListItemButton
               sx={{ pl: 4 }}
-              onClick={() => dispatch(getWMTSOverlays({ workspace: WMTS_WORKSPACE }))}
+              onClick={() =>
+                dispatch(getWMTSOverlays({ workspace: WMTS_WORKSPACE }))
+              }
             >
               <ListItemText
                 primary="Failed to load — click to retry"

--- a/src/UI/components/map/layers/SpeciesOverlayList.tsx
+++ b/src/UI/components/map/layers/SpeciesOverlayList.tsx
@@ -12,34 +12,33 @@ import ExpandMore from '@mui/icons-material/ExpandMore';
 import LayersIcon from '@mui/icons-material/Layers';
 
 import { useAppDispatch, useAppSelector } from '../../../state/hooks';
-import { getWMTSOverlays, WMTSLayerInfo } from '../../../state/map/actions/getWmtsoverlays';
+import { getWMTSOverlays } from '../../../state/map/actions/getWmtsoverlays';
 import { toggleWMTSLayerVisibility } from '../../../state/map/mapSlice';
 import { WMTSWorkspacesEnum } from '../../../state/state.types';
 
-interface IROverlayListProps {
+interface SpeciesOverlayListProps {
   sectionTitle?: string;
   sectionFlag: string;
 }
 
-export const IROverlayList: React.FC<IROverlayListProps> = ({
-  sectionTitle = 'Insecticide Resistence Overlays',
+export const SpeciesOverlayList: React.FC<SpeciesOverlayListProps> = ({
+  sectionTitle = 'Species Overlays',
   sectionFlag,
 }) => {
   const dispatch = useAppDispatch();
   const [sectionOpen, setSectionOpen] = useState(false);
 
-  const WMTS_WORKSPACE = WMTSWorkspacesEnum.IR;
-  
+  const WMTS_WORKSPACE = WMTSWorkspacesEnum.SPECIES;
+
   const drawerOpen = useAppSelector((s) => s.map.map_drawer.open);
   const wmtsLayers = useAppSelector((s) => s.map.wmtsLayers.filter((layer) => layer.workspace === WMTS_WORKSPACE));
   const wmtsStatus = useAppSelector((s) => s.map.wmtsStatus);
   const wmtsWorkspaceLoaded = useAppSelector((s) => s.map.wmtsWorkspaces.includes(WMTS_WORKSPACE));
 
-
   // Lazy-load: only fetch when the section is first opened
   useEffect(() => {
     if (sectionOpen && wmtsStatus !== 'loading' && !wmtsWorkspaceLoaded) {
-      dispatch(getWMTSOverlays({ workspace: WMTS_WORKSPACE}));
+      dispatch(getWMTSOverlays({ workspace: WMTS_WORKSPACE }));
     }
   }, [sectionOpen, wmtsStatus, dispatch]);
 
@@ -103,7 +102,7 @@ export const IROverlayList: React.FC<IROverlayListProps> = ({
           )}
 
           {/* Layer rows */}
-          {wmtsLayers.map((layer: WMTSLayerInfo) => (
+          {wmtsLayers.map((layer: any) => (
             <Tooltip
               key={layer.name}
               title={layer.abstract ?? layer.name}
@@ -135,4 +134,4 @@ export const IROverlayList: React.FC<IROverlayListProps> = ({
   );
 };
 
-export default IROverlayList;
+export default SpeciesOverlayList;

--- a/src/UI/components/map/layers/SpeciesOverlayModal.tsx
+++ b/src/UI/components/map/layers/SpeciesOverlayModal.tsx
@@ -70,8 +70,6 @@ const HEADER_BG = 'rgba(255,255,255,0.025)';
 const BORDER_SUBTLE = 'rgba(255,255,255,0.08)';
 const TEXT_PRIMARY = '#e8ede9';
 const TEXT_MUTED = 'rgba(232,237,233,0.45)';
-const TEXT_FAINT = 'rgba(232,237,233,0.28)';
-
 // Desktop layout
 const SIDEBAR_OPEN_LEFT = 370;
 const SIDEBAR_CLOSED_LEFT = 80;
@@ -86,36 +84,21 @@ const VECTOR_PANEL_MIN_HEIGHT = 52;
 const EASE = 'cubic-bezier(0.4, 0, 0.2, 1)';
 const TRANSITION = `all 0.32s ${EASE}`;
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-const getGroupKey = (name: string): string =>
-  name.includes('_ir_') ? name.split('_ir_')[0] : name.split('_')[0];
-
-const normalise = (s: string) => s.toLowerCase().replace(/[\s_-]/g, '');
-
-const groupLayers = (layers: WMTSLayer[]): Record<string, WMTSLayer[]> =>
-  layers.reduce<Record<string, WMTSLayer[]>>((acc, layer) => {
-    const key = getGroupKey(layer.name);
-    acc[key] = acc[key] ?? [];
-    acc[key].push(layer);
-    return acc;
-  }, {});
-
 // ─── Custom Hook ──────────────────────────────────────────────────────────────
 
-const useIROverlays = () => {
+const useSpeciesOverlays = () => {
   const dispatch = useAppDispatch();
   const [isVisible, setIsVisible] = useState(false);
-  const [expandedGroup, setExpandedGroup] = useState<string | null>(null);
   const [isMinimized, setIsMinimized] = useState(false);
 
-  const WMTS_WORKSPACE = WMTSWorkspacesEnum.IR;
+  const WMTS_WORKSPACE = WMTSWorkspacesEnum.SPECIES;
 
   const isSidebarOpen = useAppSelector((s) => s.map.map_drawer.open);
-  const drawerRequestOpen = useAppSelector((s) => s.map.map_drawer.ir_overlays);
+  const drawerRequestOpen = useAppSelector((s) => s.map.map_drawer.overlays);
   const wmtsLayers = useAppSelector((s) => s.map.wmtsLayers.filter((layer) => layer.workspace === WMTS_WORKSPACE)) as WMTSLayer[];
   const wmtsStatus = useAppSelector((s) => s.map.wmtsStatus);
-    const wmtsWorkspaceLoaded = useAppSelector((s) => s.map.wmtsWorkspaces.includes(WMTS_WORKSPACE));
+  const wmtsWorkspaceLoaded = useAppSelector((s) => s.map.wmtsWorkspaces.includes(WMTS_WORKSPACE));
+
 
   useEffect(() => {
     if (drawerRequestOpen) {
@@ -124,18 +107,13 @@ const useIROverlays = () => {
     }
   }, [drawerRequestOpen, wmtsStatus, dispatch]);
 
-  const grouped = useMemo(() => groupLayers(wmtsLayers), [wmtsLayers]);
-  const toggleGroup = useCallback(
-    (name: string) => setExpandedGroup((prev) => (prev === name ? null : name)),
-    []
-  );
   const toggleMinimized = useCallback(
     () => setIsMinimized((prev) => !prev),
     []
   );
   const handleClose = useCallback(() => {
     setIsVisible(false);
-    dispatch(drawerListToggle('ir_overlays'));
+    dispatch(drawerListToggle('overlays'));
   }, [dispatch]);
   const handleToggleLayer = useCallback(
     (name: string) => dispatch(toggleWMTSLayerVisibility(name)),
@@ -146,148 +124,146 @@ const useIROverlays = () => {
     isVisible,
     isMinimized,
     isSidebarOpen,
-    expandedGroup,
     wmtsStatus,
-    grouped,
-    toggleGroup,
+    wmtsLayers,
     toggleMinimized,
     handleClose,
     handleToggleLayer,
   };
 };
 
-// ─── Resistance Legend ────────────────────────────────────────────────────────
-const LEGEND_STOPS = [
-  { label: 'Resistant', color: '#f44336', short: 'R' },
-  { label: 'Moderate', color: '#ffeb3b', short: 'M' },
-  { label: 'Possible', color: '#cddc39', short: 'P' },
-  { label: 'Susceptible', color: '#4caf50', short: 'S' },
-];
+// // ─── Resistance Legend ────────────────────────────────────────────────────────
+// const LEGEND_STOPS = [
+//   { label: 'Resistant', color: '#f44336', short: 'R' },
+//   { label: 'Moderate', color: '#ffeb3b', short: 'M' },
+//   { label: 'Possible', color: '#cddc39', short: 'P' },
+//   { label: 'Susceptible', color: '#4caf50', short: 'S' },
+// ];
 
-const ResistanceLegend: React.FC = () => {
-  const [hovered, setHovered] = useState<number | null>(null);
+// const ResistanceLegend: React.FC = () => {
+//   const [hovered, setHovered] = useState<number | null>(null);
 
-  return (
-    <Box sx={{ px: 1.5, pt: 1.5, pb: 2, flex: 1 }}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          mb: 1,
-        }}
-      >
-        <Typography
-          variant="caption"
-          sx={{
-            fontSize: '0.6rem',
-            letterSpacing: '1.2px',
-            textTransform: 'uppercase',
-            color: TEXT_MUTED,
-            fontWeight: 600,
-          }}
-        >
-          Resistance Legend
-        </Typography>
-      </Box>
+//   return (
+//     <Box sx={{ px: 1.5, pt: 1.5, pb: 2 }}>
+//       <Box
+//         sx={{
+//           display: 'flex',
+//           alignItems: 'center',
+//           justifyContent: 'space-between',
+//           mb: 1,
+//         }}
+//       >
+//         <Typography
+//           variant="caption"
+//           sx={{
+//             fontSize: '0.6rem',
+//             letterSpacing: '1.2px',
+//             textTransform: 'uppercase',
+//             color: TEXT_MUTED,
+//             fontWeight: 600,
+//           }}
+//         >
+//           Resistance Legend
+//         </Typography>
+//       </Box>
 
-      <Box
-        sx={{
-          position: 'relative',
-          height: 10,
-          borderRadius: '6px',
-          background:
-            'linear-gradient(to right, #f44336, #ff9800, #ffeb3b, #cddc39, #4caf50)',
-          mb: 1,
-          boxShadow: 'inset 0 1px 3px rgba(0,0,0,0.3)',
-        }}
-      >
-        {LEGEND_STOPS.map((stop, i) => (
-          <Box
-            key={stop.label}
-            onMouseEnter={() => setHovered(i)}
-            onMouseLeave={() => setHovered(null)}
-            sx={{
-              position: 'absolute',
-              left: `${(i / (LEGEND_STOPS.length - 1)) * 100}%`,
-              top: '50%',
-              transform: 'translate(-50%, -50%)',
-              width: hovered === i ? 14 : 10,
-              height: hovered === i ? 14 : 10,
-              borderRadius: '50%',
-              background: stop.color,
-              border: `2px solid ${
-                hovered === i ? '#fff' : 'rgba(255,255,255,0.3)'
-              }`,
-              cursor: 'pointer',
-              transition: TRANSITION,
-              zIndex: 2,
-            }}
-          />
-        ))}
-      </Box>
+//       <Box
+//         sx={{
+//           position: 'relative',
+//           height: 10,
+//           borderRadius: '6px',
+//           background:
+//             'linear-gradient(to right, #f44336, #ff9800, #ffeb3b, #cddc39, #4caf50)',
+//           mb: 1,
+//           boxShadow: 'inset 0 1px 3px rgba(0,0,0,0.3)',
+//         }}
+//       >
+//         {LEGEND_STOPS.map((stop, i) => (
+//           <Box
+//             key={stop.label}
+//             onMouseEnter={() => setHovered(i)}
+//             onMouseLeave={() => setHovered(null)}
+//             sx={{
+//               position: 'absolute',
+//               left: `${(i / (LEGEND_STOPS.length - 1)) * 100}%`,
+//               top: '50%',
+//               transform: 'translate(-50%, -50%)',
+//               width: hovered === i ? 14 : 10,
+//               height: hovered === i ? 14 : 10,
+//               borderRadius: '50%',
+//               background: stop.color,
+//               border: `2px solid ${
+//                 hovered === i ? '#fff' : 'rgba(255,255,255,0.3)'
+//               }`,
+//               cursor: 'pointer',
+//               transition: TRANSITION,
+//               zIndex: 2,
+//             }}
+//           />
+//         ))}
+//       </Box>
 
-      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-        {LEGEND_STOPS.map((stop, i) => (
-          <Typography
-            key={stop.label}
-            variant="caption"
-            sx={{
-              fontSize: '0.6rem',
-              color: hovered === i ? stop.color : TEXT_MUTED,
-              fontWeight: hovered === i ? 700 : 400,
-            }}
-          >
-            {stop.label}
-          </Typography>
-        ))}
-      </Box>
+//       <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+//         {LEGEND_STOPS.map((stop, i) => (
+//           <Typography
+//             key={stop.label}
+//             variant="caption"
+//             sx={{
+//               fontSize: '0.6rem',
+//               color: hovered === i ? stop.color : TEXT_MUTED,
+//               fontWeight: hovered === i ? 700 : 400,
+//             }}
+//           >
+//             {stop.label}
+//           </Typography>
+//         ))}
+//       </Box>
 
-      <Fade in={hovered !== null} timeout={200}>
-        <Box
-          sx={{
-            mt: 1,
-            px: 1.5,
-            py: 0.6,
-            borderRadius: '6px',
-            background:
-              hovered !== null
-                ? `${LEGEND_STOPS[hovered].color}22`
-                : 'transparent',
-            border: `1px solid ${
-              hovered !== null
-                ? LEGEND_STOPS[hovered].color + '44'
-                : 'transparent'
-            }`,
-            minHeight: 28,
-          }}
-        >
-          {hovered !== null && (
-            <Typography
-              variant="caption"
-              sx={{
-                fontSize: '0.68rem',
-                color: LEGEND_STOPS[hovered].color,
-                fontWeight: 500,
-              }}
-            >
-              <strong>{LEGEND_STOPS[hovered].label}</strong>
-              {' — '}
-              {
-                [
-                  'Full resistance.',
-                  'Moderate resistance.',
-                  'Low-level signals.',
-                  'No signs.',
-                ][hovered]
-              }
-            </Typography>
-          )}
-        </Box>
-      </Fade>
-    </Box>
-  );
-};
+//       <Fade in={hovered !== null} timeout={200}>
+//         <Box
+//           sx={{
+//             mt: 1,
+//             px: 1.5,
+//             py: 0.6,
+//             borderRadius: '6px',
+//             background:
+//               hovered !== null
+//                 ? `${LEGEND_STOPS[hovered].color}22`
+//                 : 'transparent',
+//             border: `1px solid ${
+//               hovered !== null
+//                 ? LEGEND_STOPS[hovered].color + '44'
+//                 : 'transparent'
+//             }`,
+//             minHeight: 28,
+//           }}
+//         >
+//           {hovered !== null && (
+//             <Typography
+//               variant="caption"
+//               sx={{
+//                 fontSize: '0.68rem',
+//                 color: LEGEND_STOPS[hovered].color,
+//                 fontWeight: 500,
+//               }}
+//             >
+//               <strong>{LEGEND_STOPS[hovered].label}</strong>
+//               {' — '}
+//               {
+//                 [
+//                   'Full resistance.',
+//                   'Moderate resistance.',
+//                   'Low-level signals.',
+//                   'No signs.',
+//                 ][hovered]
+//               }
+//             </Typography>
+//           )}
+//         </Box>
+//       </Fade>
+//     </Box>
+//   );
+// };
 
 const ScrollHint: React.FC<{ visible: boolean }> = ({ visible }) => (
   <Fade in={visible} timeout={400}>
@@ -326,8 +302,9 @@ const ScrollHint: React.FC<{ visible: boolean }> = ({ visible }) => (
 const LayerItem: React.FC<LayerItemProps> = React.memo(
   ({ layer, onToggle }) => {
     const label =
-      layer.title ??
-      layer.name.split('_ir_').pop()?.replace(/_/g, ' ') ??
+      layer.title ?
+        layer.title.split('Species_Distribution_Maps__')[1]?.replace(/_/g, ' ') ?? layer.title
+      : layer.name.split('Species_Distribution_Maps__')[1]?.replace(/_/g, ' ') ??
       layer.name;
     return (
       <ListItemButton
@@ -375,149 +352,6 @@ const LayerItem: React.FC<LayerItemProps> = React.memo(
 );
 LayerItem.displayName = 'LayerItem';
 
-const LayerGroup: React.FC<LayerGroupProps> = React.memo(
-  ({ groupName, layers, isExpanded, onToggleGroup, onToggleLayer }) => {
-    const activeCount = useMemo(
-      () => layers.filter((l) => l.isVisible).length,
-      [layers]
-    );
-    const displayName = groupName.replace(/-/g, ' ');
-
-    const isSingleDuplicate = useMemo(() => {
-      if (layers.length !== 1) return false;
-      const layer = layers[0];
-      const layerLabel =
-        layer.title ??
-        layer.name.split('_ir_').pop()?.replace(/_/g, ' ') ??
-        layer.name;
-      return normalise(layerLabel) === normalise(displayName);
-    }, [layers, displayName]);
-
-    if (isSingleDuplicate) {
-      const layer = layers[0];
-      return (
-        <Box sx={{ mb: 0.4 }}>
-          <ListItemButton
-            onClick={() => onToggleLayer(layer.name)}
-            sx={{
-              borderRadius: '8px',
-              py: 0.9,
-              px: 1.5,
-              background: layer.isVisible ? ACCENT_DIM : 'transparent',
-              border: `1px solid ${
-                layer.isVisible ? ACCENT_BORDER : 'transparent'
-              }`,
-              '&:hover': {
-                background: 'rgba(255,255,255,0.04)',
-                transform: 'translateX(3px)',
-              },
-            }}
-          >
-            <Checkbox
-              checked={layer.isVisible}
-              size="small"
-              disableRipple
-              sx={{
-                p: 0.5,
-                mr: 1,
-                color: 'rgba(255,255,255,0.18)',
-                '&.Mui-checked': { color: ACCENT },
-              }}
-            />
-            <Typography
-              variant="body2"
-              sx={{
-                flexGrow: 1,
-                color: layer.isVisible ? ACCENT : TEXT_PRIMARY,
-                textTransform: 'capitalize',
-              }}
-            >
-              {displayName}
-            </Typography>
-          </ListItemButton>
-        </Box>
-      );
-    }
-
-    return (
-      <Box sx={{ mb: 0.4 }}>
-        <ListItemButton
-          onClick={() => onToggleGroup(groupName)}
-          sx={{
-            borderRadius: '8px',
-            py: 0.9,
-            px: 1.5,
-            background: isExpanded ? ACCENT_DIM : 'transparent',
-            border: `1px solid ${isExpanded ? ACCENT_BORDER : 'transparent'}`,
-            '&:hover': {
-              background: 'rgba(255,255,255,0.04)',
-              transform: 'translateX(3px)',
-            },
-          }}
-        >
-          <Typography
-            variant="body2"
-            sx={{
-              flexGrow: 1,
-              fontWeight: isExpanded ? 600 : 400,
-              color: activeCount > 0 ? ACCENT : TEXT_PRIMARY,
-              textTransform: 'capitalize',
-            }}
-          >
-            {displayName}
-          </Typography>
-          {activeCount > 0 && !isExpanded && (
-            <Box
-              component="span"
-              sx={{
-                mr: 1,
-                px: 0.75,
-                borderRadius: '4px',
-                background: ACCENT,
-                color: '#0f1a12',
-                fontSize: '0.62rem',
-                fontWeight: 800,
-              }}
-            >
-              {activeCount}
-            </Box>
-          )}
-          {isExpanded ? (
-            <ExpandLess fontSize="small" sx={{ color: ACCENT }} />
-          ) : (
-            <ExpandMore fontSize="small" sx={{ color: ACCENT }} />
-          )}
-        </ListItemButton>
-        {/* <Collapse in={isExpanded} timeout={280} unmountOnExit> */}
-        <Collapse in={isExpanded} timeout={280}>
-          <Box sx={{ position: 'relative', mt: 0.25, pl: 2.5, pb: 0.5 }}>
-            <Box
-              sx={{
-                position: 'absolute',
-                left: 14,
-                top: 4,
-                bottom: 4,
-                width: '2px',
-                background: `linear-gradient(to bottom, ${ACCENT_BORDER}, transparent)`,
-              }}
-            />
-            <List dense disablePadding>
-              {layers.map((layer) => (
-                <LayerItem
-                  key={layer.name}
-                  layer={layer}
-                  onToggle={onToggleLayer}
-                />
-              ))}
-            </List>
-          </Box>
-        </Collapse>
-      </Box>
-    );
-  }
-);
-LayerGroup.displayName = 'LayerGroup';
-
 const PanelHeader: React.FC<{
   isMinimized: boolean;
   isMobile: boolean;
@@ -561,7 +395,7 @@ const PanelHeader: React.FC<{
             color: TEXT_PRIMARY,
           }}
         >
-          Insecticide Resistance
+          Species
         </Typography>
         <Typography
           variant="caption"
@@ -602,17 +436,13 @@ const PanelContent: React.FC<{
   isMinimized: boolean;
   isMobile: boolean;
   wmtsStatus: string;
-  grouped: Record<string, WMTSLayer[]>;
-  expandedGroup: string | null;
-  onToggleGroup: (name: string) => void;
+  wmtsLayers: WMTSLayer[];
   onToggleLayer: (name: string) => void;
 }> = ({
   isMinimized,
   isMobile,
   wmtsStatus,
-  grouped,
-  expandedGroup,
-  onToggleGroup,
+  wmtsLayers,
   onToggleLayer,
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -653,61 +483,66 @@ const PanelContent: React.FC<{
         '&.MuiCollapse-entered .MuiCollapse-wrapperInner': { flexGrow: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }
       }}
     >
-      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-        <Box sx={{ overflow: 'hidden', flex: 9, position: 'relative', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-          <Box
-            ref={scrollRef}
-            sx={{
-              flex: 1,
-              minHeight: 0,
-              px: 1,
-              py: 1,
-              overflowY: 'auto',
-              maxHeight: isMobile
-                ? `calc(${MOBILE_SHEET_MAX_HEIGHT} - 160px)`
-                : '100%',
-              '&::-webkit-scrollbar': { width: 8 },
-              '&::-webkit-scrollbar-thumb': {
-                background: ACCENT,
-                borderRadius: 10,
-              },
-              pb: isMobile ? 'max(8px, env(safe-area-inset-bottom))' : 0.5,
-            }}
-          >
-            {wmtsStatus === 'loading' && (
-              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                <CircularProgress
-                  size={18}
-                  thickness={4}
-                  sx={{ color: ACCENT }}
-                />
-              </Box>
-            )}
-            {Object.entries(grouped).map(([groupName, layers]) => (
-              <LayerGroup
-                key={groupName}
-                groupName={groupName}
-                layers={layers}
-                isExpanded={expandedGroup === groupName}
-                onToggleGroup={onToggleGroup}
-                onToggleLayer={onToggleLayer}
+    <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+      <Box sx={{ overflow: 'hidden', flex: 9, position: 'relative', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+        <Box
+          ref={scrollRef}
+          sx={{
+            px: 1,
+            py: 1,
+            overflowY: 'auto',
+            maxHeight: isMobile
+              ? `calc(${MOBILE_SHEET_MAX_HEIGHT} - 160px)`
+              : '42vh',
+            '&::-webkit-scrollbar': { width: 8 },
+            '&::-webkit-scrollbar-thumb': {
+              background: ACCENT,
+              borderRadius: 10,
+            },
+            pb: isMobile ? 'max(8px, env(safe-area-inset-bottom))' : 0.5,
+          }}
+        >
+          {wmtsStatus === 'loading' && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress
+                size={18}
+                thickness={4}
+                sx={{ color: ACCENT }}
               />
-            ))}
-          </Box>
-          <ScrollHint visible={showScrollHint} />
+            </Box>
+          )}
+          {/* {Object.entries(grouped).map(([groupName, layers]) => (
+            <LayerGroup
+              key={groupName}
+              groupName={groupName}
+              layers={layers}
+              isExpanded={expandedGroup === groupName}
+              onToggleGroup={onToggleGroup}
+              onToggleLayer={onToggleLayer}
+            />
+          ))} */}
+          {wmtsLayers.map((layer) => (
+            <LayerItem
+              key={layer.name}
+              layer={layer}
+              onToggle={onToggleLayer}
+            />
+          ))}
         </Box>
-        <Box sx={{ px: 1.5, pt: 0.5 }}>
-          <Divider sx={{ borderColor: 'rgba(255,255,255,0.06)' }} />
-        </Box>
-        <ResistanceLegend />
+        <ScrollHint visible={showScrollHint} />
       </Box>
+      <Box sx={{ px: 1.5, pt: 0.5 }}>
+        <Divider sx={{ borderColor: 'rgba(255,255,255,0.06)' }} />
+      </Box>
+      {/* <ResistanceLegend /> */}
+    </Box>
     </Collapse>
   );
 };
 
 // ─── Main Component ───────────────────────────────────────────────────────────
 
-export const IROverlaysPanel: React.FC = () => {
+export const SpeciesOverlaysPanel: React.FC = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isVectorPanelVisible = useAppSelector((s) => s.map.map_drawer.open);
@@ -716,14 +551,12 @@ export const IROverlaysPanel: React.FC = () => {
     isVisible,
     isMinimized,
     isSidebarOpen,
-    expandedGroup,
     wmtsStatus,
-    grouped,
-    toggleGroup,
+    wmtsLayers,
     toggleMinimized,
     handleClose,
     handleToggleLayer,
-  } = useIROverlays();
+  } = useSpeciesOverlays();
 
   if (!isVisible) return null;
 
@@ -744,9 +577,10 @@ export const IROverlaysPanel: React.FC = () => {
             // left: 0,
             // right: 0,
             // zIndex: 1300,
+            flex: 1,
             display: 'flex',
             flexDirection: 'column',
-            overflow: 'hidden',
+            // overflow: 'hidden',
             maxHeight: isMinimized
               ? MOBILE_SHEET_MIN_HEIGHT
               : MOBILE_SHEET_MAX_HEIGHT,
@@ -790,9 +624,7 @@ export const IROverlaysPanel: React.FC = () => {
             isMinimized={isMinimized}
             isMobile
             wmtsStatus={wmtsStatus}
-            grouped={grouped}
-            expandedGroup={expandedGroup}
-            onToggleGroup={toggleGroup}
+            wmtsLayers={wmtsLayers}
             onToggleLayer={handleToggleLayer}
           />
         </Paper>
@@ -834,9 +666,7 @@ export const IROverlaysPanel: React.FC = () => {
         isMinimized={isMinimized}
         isMobile={false}
         wmtsStatus={wmtsStatus}
-        grouped={grouped}
-        expandedGroup={expandedGroup}
-        onToggleGroup={toggleGroup}
+        wmtsLayers={wmtsLayers}
         onToggleLayer={handleToggleLayer}
       />
     </Paper>

--- a/src/UI/components/map/layers/SpeciesOverlayModal.tsx
+++ b/src/UI/components/map/layers/SpeciesOverlayModal.tsx
@@ -95,15 +95,19 @@ const useSpeciesOverlays = () => {
 
   const isSidebarOpen = useAppSelector((s) => s.map.map_drawer.open);
   const drawerRequestOpen = useAppSelector((s) => s.map.map_drawer.overlays);
-  const wmtsLayers = useAppSelector((s) => s.map.wmtsLayers.filter((layer) => layer.workspace === WMTS_WORKSPACE)) as WMTSLayer[];
+  const wmtsLayers = useAppSelector((s) =>
+    s.map.wmtsLayers.filter((layer) => layer.workspace === WMTS_WORKSPACE)
+  ) as WMTSLayer[];
   const wmtsStatus = useAppSelector((s) => s.map.wmtsStatus);
-  const wmtsWorkspaceLoaded = useAppSelector((s) => s.map.wmtsWorkspaces.includes(WMTS_WORKSPACE));
-
+  const wmtsWorkspaceLoaded = useAppSelector((s) =>
+    s.map.wmtsWorkspaces.includes(WMTS_WORKSPACE)
+  );
 
   useEffect(() => {
     if (drawerRequestOpen) {
       setIsVisible(true);
-      if (wmtsStatus !== 'loading' && !wmtsWorkspaceLoaded) dispatch(getWMTSOverlays({ workspace: WMTS_WORKSPACE }));
+      if (wmtsStatus !== 'loading' && !wmtsWorkspaceLoaded)
+        dispatch(getWMTSOverlays({ workspace: WMTS_WORKSPACE }));
     }
   }, [drawerRequestOpen, wmtsStatus, dispatch]);
 
@@ -301,11 +305,13 @@ const ScrollHint: React.FC<{ visible: boolean }> = ({ visible }) => (
 
 const LayerItem: React.FC<LayerItemProps> = React.memo(
   ({ layer, onToggle }) => {
-    const label =
-      layer.title ?
-        layer.title.split('Species_Distribution_Maps__')[1]?.replace(/_/g, ' ') ?? layer.title
-      : layer.name.split('Species_Distribution_Maps__')[1]?.replace(/_/g, ' ') ??
-      layer.name;
+    const label = layer.title
+      ? layer.title
+          .split('Species_Distribution_Maps__')[1]
+          ?.replace(/_/g, ' ') ?? layer.title
+      : layer.name
+          .split('Species_Distribution_Maps__')[1]
+          ?.replace(/_/g, ' ') ?? layer.name;
     return (
       <ListItemButton
         onClick={() => onToggle(layer.name)}
@@ -438,13 +444,7 @@ const PanelContent: React.FC<{
   wmtsStatus: string;
   wmtsLayers: WMTSLayer[];
   onToggleLayer: (name: string) => void;
-}> = ({
-  isMinimized,
-  isMobile,
-  wmtsStatus,
-  wmtsLayers,
-  onToggleLayer,
-}) => {
+}> = ({ isMinimized, isMobile, wmtsStatus, wmtsLayers, onToggleLayer }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [showScrollHint, setShowScrollHint] = useState(false);
 
@@ -479,39 +479,66 @@ const PanelContent: React.FC<{
         display: 'flex',
         flexDirection: 'column',
         minHeight: 0,
-        '&.MuiCollapse-entered .MuiCollapse-wrapper': { flexGrow: 1, display: 'flex', flexDirection: 'column', minHeight: 0 },
-        '&.MuiCollapse-entered .MuiCollapse-wrapperInner': { flexGrow: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }
+        '&.MuiCollapse-entered .MuiCollapse-wrapper': {
+          flexGrow: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+        },
+        '&.MuiCollapse-entered .MuiCollapse-wrapperInner': {
+          flexGrow: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+        },
       }}
     >
-    <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-      <Box sx={{ overflow: 'hidden', flex: 9, position: 'relative', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+      <Box
+        sx={{
+          flex: 1,
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+        }}
+      >
         <Box
-          ref={scrollRef}
           sx={{
-            px: 1,
-            py: 1,
-            overflowY: 'auto',
-            maxHeight: isMobile
-              ? `calc(${MOBILE_SHEET_MAX_HEIGHT} - 160px)`
-              : '42vh',
-            '&::-webkit-scrollbar': { width: 8 },
-            '&::-webkit-scrollbar-thumb': {
-              background: ACCENT,
-              borderRadius: 10,
-            },
-            pb: isMobile ? 'max(8px, env(safe-area-inset-bottom))' : 0.5,
+            overflow: 'hidden',
+            flex: 9,
+            position: 'relative',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
           }}
         >
-          {wmtsStatus === 'loading' && (
-            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-              <CircularProgress
-                size={18}
-                thickness={4}
-                sx={{ color: ACCENT }}
-              />
-            </Box>
-          )}
-          {/* {Object.entries(grouped).map(([groupName, layers]) => (
+          <Box
+            ref={scrollRef}
+            sx={{
+              px: 1,
+              py: 1,
+              overflowY: 'auto',
+              maxHeight: isMobile
+                ? `calc(${MOBILE_SHEET_MAX_HEIGHT} - 160px)`
+                : '42vh',
+              '&::-webkit-scrollbar': { width: 8 },
+              '&::-webkit-scrollbar-thumb': {
+                background: ACCENT,
+                borderRadius: 10,
+              },
+              pb: isMobile ? 'max(8px, env(safe-area-inset-bottom))' : 0.5,
+            }}
+          >
+            {wmtsStatus === 'loading' && (
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                <CircularProgress
+                  size={18}
+                  thickness={4}
+                  sx={{ color: ACCENT }}
+                />
+              </Box>
+            )}
+            {/* {Object.entries(grouped).map(([groupName, layers]) => (
             <LayerGroup
               key={groupName}
               groupName={groupName}
@@ -521,21 +548,21 @@ const PanelContent: React.FC<{
               onToggleLayer={onToggleLayer}
             />
           ))} */}
-          {wmtsLayers.map((layer) => (
-            <LayerItem
-              key={layer.name}
-              layer={layer}
-              onToggle={onToggleLayer}
-            />
-          ))}
+            {wmtsLayers.map((layer) => (
+              <LayerItem
+                key={layer.name}
+                layer={layer}
+                onToggle={onToggleLayer}
+              />
+            ))}
+          </Box>
+          <ScrollHint visible={showScrollHint} />
         </Box>
-        <ScrollHint visible={showScrollHint} />
+        <Box sx={{ px: 1.5, pt: 0.5 }}>
+          <Divider sx={{ borderColor: 'rgba(255,255,255,0.06)' }} />
+        </Box>
+        {/* <ResistanceLegend /> */}
       </Box>
-      <Box sx={{ px: 1.5, pt: 0.5 }}>
-        <Divider sx={{ borderColor: 'rgba(255,255,255,0.06)' }} />
-      </Box>
-      {/* <ResistanceLegend /> */}
-    </Box>
     </Collapse>
   );
 };

--- a/src/UI/components/map/layers/drawerMap.tsx
+++ b/src/UI/components/map/layers/drawerMap.tsx
@@ -30,13 +30,18 @@ export default function DrawerMap() {
   const dispatch = useDispatch();
   const drawerWidth = 370;
 
-  const overlays = useAppSelector((state) =>
-    state.map.map_overlays.filter((l: any) => l.sourceLayer !== 'world')
-  );
+  // const overlays = useAppSelector((state) =>
+  //   state.map.map_overlays.filter((l: any) => l.sourceLayer !== 'world')
+  // );
   const baseMap = useAppSelector((state) =>
     state.map.map_overlays.filter((l: any) => l.sourceLayer === 'world')
   );
   const open = useAppSelector((state) => state.map.map_drawer.open);
+
+  const overlaysPopupOpen = useAppSelector(
+    (state) => state.map.map_drawer.overlays
+  );
+
   const irPopupOpen = useAppSelector(
     (state) => state.map.map_drawer.ir_overlays
   );
@@ -101,16 +106,58 @@ export default function DrawerMap() {
           sectionFlag="filters"
         />
         <Divider />
-        <DrawerList
+        {/* <DrawerList
           sectionTitle={t('drawerMap.overlaysTitle')}
           overlays={overlays}
           sectionFlag="overlays"
-        />
+        /> */}
+
+        <ListItemButton
+          onClick={() => {
+            if (!overlaysPopupOpen) dispatch(drawerListToggle('overlays'))
+          }}
+          sx={{
+            minHeight: 48,
+            justifyContent: open ? 'initial' : 'center',
+            px: 2.5,
+            my: 0.5,
+            borderRadius: '12px',
+            backgroundColor: overlaysPopupOpen
+              ? 'rgba(56, 189, 248, 0.1)'
+              : 'transparent',
+            color: overlaysPopupOpen ? '#323435' : 'inherit',
+            '&:hover': { backgroundColor: 'rgba(56, 189, 248, 0.05)' },
+          }}
+        >
+          <ListItemIcon
+            sx={{
+              minWidth: 0,
+              mr: open ? 3 : 'auto',
+              justifyContent: 'center',
+              // Uses the same dark grey for both states to stay uniform
+              color: 'rgba(0, 0, 0, 0.54)',
+            }}
+          >
+            <LayersIcon />
+          </ListItemIcon>
+
+          {open && (
+            <ListItemText
+              primary={
+                <Typography variant="body2" sx={{ fontWeight: 400 }}>
+                  {t('drawerMap.overlaysTitle')}
+                </Typography>
+              }
+            />
+          )}
+        </ListItemButton>
 
         <Divider />
 
         <ListItemButton
-          onClick={() => dispatch(drawerListToggle('ir_overlays'))}
+          onClick={() => {
+            if (!irPopupOpen) dispatch(drawerListToggle('ir_overlays'))
+          }}
           sx={{
             minHeight: 48,
             justifyContent: open ? 'initial' : 'center',

--- a/src/UI/components/map/layers/drawerMap.tsx
+++ b/src/UI/components/map/layers/drawerMap.tsx
@@ -114,7 +114,7 @@ export default function DrawerMap() {
 
         <ListItemButton
           onClick={() => {
-            if (!overlaysPopupOpen) dispatch(drawerListToggle('overlays'))
+            if (!overlaysPopupOpen) dispatch(drawerListToggle('overlays'));
           }}
           sx={{
             minHeight: 48,
@@ -156,7 +156,7 @@ export default function DrawerMap() {
 
         <ListItemButton
           onClick={() => {
-            if (!irPopupOpen) dispatch(drawerListToggle('ir_overlays'))
+            if (!irPopupOpen) dispatch(drawerListToggle('ir_overlays'));
           }}
           sx={{
             minHeight: 48,

--- a/src/UI/components/map/layers/irOverlayList.tsx
+++ b/src/UI/components/map/layers/irOverlayList.tsx
@@ -12,7 +12,10 @@ import ExpandMore from '@mui/icons-material/ExpandMore';
 import LayersIcon from '@mui/icons-material/Layers';
 
 import { useAppDispatch, useAppSelector } from '../../../state/hooks';
-import { getWMTSOverlays, WMTSLayerInfo } from '../../../state/map/actions/getWmtsoverlays';
+import {
+  getWMTSOverlays,
+  WMTSLayerInfo,
+} from '../../../state/map/actions/getWmtsoverlays';
 import { toggleWMTSLayerVisibility } from '../../../state/map/mapSlice';
 import { WMTSWorkspacesEnum } from '../../../state/state.types';
 
@@ -29,17 +32,20 @@ export const IROverlayList: React.FC<IROverlayListProps> = ({
   const [sectionOpen, setSectionOpen] = useState(false);
 
   const WMTS_WORKSPACE = WMTSWorkspacesEnum.IR;
-  
-  const drawerOpen = useAppSelector((s) => s.map.map_drawer.open);
-  const wmtsLayers = useAppSelector((s) => s.map.wmtsLayers.filter((layer) => layer.workspace === WMTS_WORKSPACE));
-  const wmtsStatus = useAppSelector((s) => s.map.wmtsStatus);
-  const wmtsWorkspaceLoaded = useAppSelector((s) => s.map.wmtsWorkspaces.includes(WMTS_WORKSPACE));
 
+  const drawerOpen = useAppSelector((s) => s.map.map_drawer.open);
+  const wmtsLayers = useAppSelector((s) =>
+    s.map.wmtsLayers.filter((layer) => layer.workspace === WMTS_WORKSPACE)
+  );
+  const wmtsStatus = useAppSelector((s) => s.map.wmtsStatus);
+  const wmtsWorkspaceLoaded = useAppSelector((s) =>
+    s.map.wmtsWorkspaces.includes(WMTS_WORKSPACE)
+  );
 
   // Lazy-load: only fetch when the section is first opened
   useEffect(() => {
     if (sectionOpen && wmtsStatus !== 'loading' && !wmtsWorkspaceLoaded) {
-      dispatch(getWMTSOverlays({ workspace: WMTS_WORKSPACE}));
+      dispatch(getWMTSOverlays({ workspace: WMTS_WORKSPACE }));
     }
   }, [sectionOpen, wmtsStatus, dispatch]);
 
@@ -82,7 +88,9 @@ export const IROverlayList: React.FC<IROverlayListProps> = ({
           {wmtsStatus === 'failed' && (
             <ListItemButton
               sx={{ pl: 4 }}
-              onClick={() => dispatch(getWMTSOverlays({ workspace: WMTS_WORKSPACE }))}
+              onClick={() =>
+                dispatch(getWMTSOverlays({ workspace: WMTS_WORKSPACE }))
+              }
             >
               <ListItemText
                 primary="Failed to load — click to retry"

--- a/src/UI/components/map/layers/irOverlayModal.tsx
+++ b/src/UI/components/map/layers/irOverlayModal.tsx
@@ -113,14 +113,19 @@ const useIROverlays = () => {
 
   const isSidebarOpen = useAppSelector((s) => s.map.map_drawer.open);
   const drawerRequestOpen = useAppSelector((s) => s.map.map_drawer.ir_overlays);
-  const wmtsLayers = useAppSelector((s) => s.map.wmtsLayers.filter((layer) => layer.workspace === WMTS_WORKSPACE)) as WMTSLayer[];
+  const wmtsLayers = useAppSelector((s) =>
+    s.map.wmtsLayers.filter((layer) => layer.workspace === WMTS_WORKSPACE)
+  ) as WMTSLayer[];
   const wmtsStatus = useAppSelector((s) => s.map.wmtsStatus);
-    const wmtsWorkspaceLoaded = useAppSelector((s) => s.map.wmtsWorkspaces.includes(WMTS_WORKSPACE));
+  const wmtsWorkspaceLoaded = useAppSelector((s) =>
+    s.map.wmtsWorkspaces.includes(WMTS_WORKSPACE)
+  );
 
   useEffect(() => {
     if (drawerRequestOpen) {
       setIsVisible(true);
-      if (wmtsStatus !== 'loading' && !wmtsWorkspaceLoaded) dispatch(getWMTSOverlays({ workspace: WMTS_WORKSPACE }));
+      if (wmtsStatus !== 'loading' && !wmtsWorkspaceLoaded)
+        dispatch(getWMTSOverlays({ workspace: WMTS_WORKSPACE }));
     }
   }, [drawerRequestOpen, wmtsStatus, dispatch]);
 
@@ -649,12 +654,39 @@ const PanelContent: React.FC<{
         display: 'flex',
         flexDirection: 'column',
         minHeight: 0,
-        '&.MuiCollapse-entered .MuiCollapse-wrapper': { flexGrow: 1, display: 'flex', flexDirection: 'column', minHeight: 0 },
-        '&.MuiCollapse-entered .MuiCollapse-wrapperInner': { flexGrow: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }
+        '&.MuiCollapse-entered .MuiCollapse-wrapper': {
+          flexGrow: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+        },
+        '&.MuiCollapse-entered .MuiCollapse-wrapperInner': {
+          flexGrow: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+        },
       }}
     >
-      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-        <Box sx={{ overflow: 'hidden', flex: 9, position: 'relative', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+      <Box
+        sx={{
+          flex: 1,
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+        }}
+      >
+        <Box
+          sx={{
+            overflow: 'hidden',
+            flex: 9,
+            position: 'relative',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+          }}
+        >
           <Box
             ref={scrollRef}
             sx={{

--- a/src/UI/components/map/mapView/map-v2.tsx
+++ b/src/UI/components/map/mapView/map-v2.tsx
@@ -696,7 +696,7 @@ const MapWrapperV3: React.FC<MapWrapperV3Props> = ({ doiResolverId }) => {
   return (
     <Box sx={{ display: 'flex', flexGrow: 1, position: 'relative' }}>
       <DrawerMap />
-      
+
       <OverlayPanel />
 
       <Box component="main" sx={{ flexGrow: 1, position: 'relative' }}>

--- a/src/UI/components/map/mapView/map-v2.tsx
+++ b/src/UI/components/map/mapView/map-v2.tsx
@@ -19,9 +19,6 @@ import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
 
 import GeoJSON from 'ol/format/GeoJSON';
-
-import { IROverlaysPanel } from '../layers/irOverlayModal';
-
 import 'ol/ol.css';
 
 import { useTranslations } from 'next-intl';
@@ -64,6 +61,7 @@ import DataDrawer from '../layers/dataDrawer';
 
 import MapHUD from './MapHUD';
 import MapLoader from './maploader';
+import { OverlayPanel } from '../layers/OverlayPanel';
 type MapWrapperV3Props = {
   doiResolverId?: string;
 };
@@ -698,8 +696,8 @@ const MapWrapperV3: React.FC<MapWrapperV3Props> = ({ doiResolverId }) => {
   return (
     <Box sx={{ display: 'flex', flexGrow: 1, position: 'relative' }}>
       <DrawerMap />
-      {/* Now this will be absolute relative to this Box */}
-      <IROverlaysPanel />
+      
+      <OverlayPanel />
 
       <Box component="main" sx={{ flexGrow: 1, position: 'relative' }}>
         <div

--- a/src/UI/public/messages/en copy.json
+++ b/src/UI/public/messages/en copy.json
@@ -580,7 +580,7 @@
     "areaModeOn": "Area mode on",
     "drawerMap": {
       "filtersTitle": "Filters",
-      "overlaysTitle": "Overlays",
+      "overlaysTitle": "Species Overlays",
       "baseMapTitle": "Base Map",
       "downloadTitle": "Download"
     },

--- a/src/UI/public/messages/en.json
+++ b/src/UI/public/messages/en.json
@@ -583,7 +583,7 @@
     "areaModeOn": "Area mode on",
     "drawerMap": {
       "filtersTitle": "Filters",
-      "overlaysTitle": "Overlays",
+      "overlaysTitle": "Species Distribution Overlays",
       "baseMapTitle": "Base Map",
       "iroverlaysTitle": "Insecticide Resistance Overlays",
       "downloadTitle": "Download"

--- a/src/UI/state/map/actions/getWmtsoverlays.ts
+++ b/src/UI/state/map/actions/getWmtsoverlays.ts
@@ -22,64 +22,60 @@ export interface GetWMTSOverlaysResut {
   workspace: WMTSWorkspacesEnum;
 }
 
-export const getWMTSOverlays = createAsyncThunk<GetWMTSOverlaysResut, GetWMTSOverlaysProps>(
-  'map/getWMTSOverlays',
-  async (props, { rejectWithValue }) => {
-    try {
-      const url = `${GEOSERVER_BASE}/${props.workspace}/wms?SERVICE=WMS&REQUEST=GetCapabilities`;
-      const res = await fetch(url);
+export const getWMTSOverlays = createAsyncThunk<
+  GetWMTSOverlaysResut,
+  GetWMTSOverlaysProps
+>('map/getWMTSOverlays', async (props, { rejectWithValue }) => {
+  try {
+    const url = `${GEOSERVER_BASE}/${props.workspace}/wms?SERVICE=WMS&REQUEST=GetCapabilities`;
+    const res = await fetch(url);
 
-      if (!res.ok) {
-        return rejectWithValue(`GeoServer responded with status ${res.status}`);
-      }
-
-      const xmlText = await res.text();
-      const parser = new DOMParser();
-      const xml = parser.parseFromString(xmlText, 'application/xml');
-
-      const parseError = xml.querySelector('parsererror');
-      if (parseError) {
-        return rejectWithValue('Failed to parse WMS GetCapabilities XML');
-      }
-
-      const layers: WMTSLayerInfo[] = [];
-      const layerNodes = xml.querySelectorAll('Layer[queryable="1"]');
-
-      console.log('[WMS] Found queryable layers:', layerNodes.length);
-
-      layerNodes.forEach((layerNode) => {
-        const name = layerNode.querySelector('Name')?.textContent?.trim() ?? '';
-        const title =
-          layerNode.querySelector('Title')?.textContent?.trim() ?? name;
-        const abstract = layerNode
-          .querySelector('Abstract')
-          ?.textContent?.trim();
-
-        if (!name) return;
-
-        console.log('[WMS] Including layer:', name);
-
-        layers.push({
-          name,
-          title,
-          abstract,
-          isVisible: false,
-          wmsUrl: `${GEOSERVER_BASE}/${props.workspace}/wms`,
-          workspace: props.workspace,
-          wmsParams: JSON.stringify({
-            LAYERS: name,
-            TILED: true,
-            FORMAT: 'image/png',
-            TRANSPARENT: true,
-          }),
-        });
-      });
-
-      return {layers, workspace: props.workspace};
-    } catch (err: any) {
-      return rejectWithValue(
-        err.message ?? 'Unknown error fetching WMS layers'
-      );
+    if (!res.ok) {
+      return rejectWithValue(`GeoServer responded with status ${res.status}`);
     }
+
+    const xmlText = await res.text();
+    const parser = new DOMParser();
+    const xml = parser.parseFromString(xmlText, 'application/xml');
+
+    const parseError = xml.querySelector('parsererror');
+    if (parseError) {
+      return rejectWithValue('Failed to parse WMS GetCapabilities XML');
+    }
+
+    const layers: WMTSLayerInfo[] = [];
+    const layerNodes = xml.querySelectorAll('Layer[queryable="1"]');
+
+    console.log('[WMS] Found queryable layers:', layerNodes.length);
+
+    layerNodes.forEach((layerNode) => {
+      const name = layerNode.querySelector('Name')?.textContent?.trim() ?? '';
+      const title =
+        layerNode.querySelector('Title')?.textContent?.trim() ?? name;
+      const abstract = layerNode.querySelector('Abstract')?.textContent?.trim();
+
+      if (!name) return;
+
+      console.log('[WMS] Including layer:', name);
+
+      layers.push({
+        name,
+        title,
+        abstract,
+        isVisible: false,
+        wmsUrl: `${GEOSERVER_BASE}/${props.workspace}/wms`,
+        workspace: props.workspace,
+        wmsParams: JSON.stringify({
+          LAYERS: name,
+          TILED: true,
+          FORMAT: 'image/png',
+          TRANSPARENT: true,
+        }),
+      });
+    });
+
+    return { layers, workspace: props.workspace };
+  } catch (err: any) {
+    return rejectWithValue(err.message ?? 'Unknown error fetching WMS layers');
   }
-);
+});

--- a/src/UI/state/map/actions/getWmtsoverlays.ts
+++ b/src/UI/state/map/actions/getWmtsoverlays.ts
@@ -1,22 +1,32 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
+import { WMTSWorkspacesEnum } from '../../state.types';
 
 export interface WMTSLayerInfo {
   name: string;
   title: string;
   abstract?: string;
   isVisible: boolean;
+  workspace: WMTSWorkspacesEnum;
   wmsUrl: string;
   wmsParams: string;
 }
 
 const GEOSERVER_BASE = 'https://test-dmmg.icipe.org/geoserver';
-const TARGET_WORKSPACE = 'ir_maps';
 
-export const getWMTSOverlays = createAsyncThunk<WMTSLayerInfo[]>(
+interface GetWMTSOverlaysProps {
+  workspace: WMTSWorkspacesEnum;
+}
+
+export interface GetWMTSOverlaysResut {
+  layers: WMTSLayerInfo[];
+  workspace: WMTSWorkspacesEnum;
+}
+
+export const getWMTSOverlays = createAsyncThunk<GetWMTSOverlaysResut, GetWMTSOverlaysProps>(
   'map/getWMTSOverlays',
-  async (_, { rejectWithValue }) => {
+  async (props, { rejectWithValue }) => {
     try {
-      const url = `${GEOSERVER_BASE}/${TARGET_WORKSPACE}/wms?SERVICE=WMS&REQUEST=GetCapabilities`;
+      const url = `${GEOSERVER_BASE}/${props.workspace}/wms?SERVICE=WMS&REQUEST=GetCapabilities`;
       const res = await fetch(url);
 
       if (!res.ok) {
@@ -54,7 +64,8 @@ export const getWMTSOverlays = createAsyncThunk<WMTSLayerInfo[]>(
           title,
           abstract,
           isVisible: false,
-          wmsUrl: `${GEOSERVER_BASE}/${TARGET_WORKSPACE}/wms`,
+          wmsUrl: `${GEOSERVER_BASE}/${props.workspace}/wms`,
+          workspace: props.workspace,
           wmsParams: JSON.stringify({
             LAYERS: name,
             TILED: true,
@@ -64,7 +75,7 @@ export const getWMTSOverlays = createAsyncThunk<WMTSLayerInfo[]>(
         });
       });
 
-      return layers;
+      return {layers, workspace: props.workspace};
     } catch (err: any) {
       return rejectWithValue(
         err.message ?? 'Unknown error fetching WMS layers'

--- a/src/UI/state/map/mapSlice.ts
+++ b/src/UI/state/map/mapSlice.ts
@@ -1,5 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { WMTSWorkspacesEnum, MapOverlay, MapStyles, VectorAtlasFilters } from '../state.types';
+import {
+  WMTSWorkspacesEnum,
+  MapOverlay,
+  MapStyles,
+  VectorAtlasFilters,
+} from '../state.types';
 import { getMapStyles } from './actions/getMapStyles';
 import { getTileServerOverlays } from './actions/getTileServerOverlays';
 import { countryList, speciesList } from './utils/countrySpeciesLists';
@@ -259,7 +264,8 @@ export const mapSlice = createSlice({
       .addCase(getWMTSOverlays.fulfilled, (state, action) => {
         state.wmtsStatus = 'succeeded';
         state.wmtsLayers.push(...action.payload.layers);
-        if (!state.wmtsWorkspaces.includes(action.payload.workspace)) state.wmtsWorkspaces.push(action.payload.workspace);
+        if (!state.wmtsWorkspaces.includes(action.payload.workspace))
+          state.wmtsWorkspaces.push(action.payload.workspace);
       })
       .addCase(getWMTSOverlays.rejected, (state) => {
         state.wmtsStatus = 'failed';

--- a/src/UI/state/map/mapSlice.ts
+++ b/src/UI/state/map/mapSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { MapOverlay, MapStyles, VectorAtlasFilters } from '../state.types';
+import { WMTSWorkspacesEnum, MapOverlay, MapStyles, VectorAtlasFilters } from '../state.types';
 import { getMapStyles } from './actions/getMapStyles';
 import { getTileServerOverlays } from './actions/getTileServerOverlays';
 import { countryList, speciesList } from './utils/countrySpeciesLists';
@@ -58,6 +58,7 @@ export interface MapState {
   processedPoints: any[];
   // ── WMTS (GeoServer IR Overlays) ──
   wmtsLayers: WMTSLayerInfo[];
+  wmtsWorkspaces: WMTSWorkspacesEnum[];
   wmtsStatus: 'idle' | 'loading' | 'succeeded' | 'failed';
 }
 
@@ -69,7 +70,7 @@ export const initialState: () => MapState = () => ({
   occurrenceLoading: false,
   currentSearchID: '',
   map_drawer: {
-    open: false,
+    open: true,
     overlays: false,
     baseMap: false,
     filters: false,
@@ -111,6 +112,7 @@ export const initialState: () => MapState = () => ({
   processedPoints: [],
   // ── WMTS initial state ──
   wmtsLayers: [],
+  wmtsWorkspaces: [],
   wmtsStatus: 'idle',
 });
 
@@ -256,7 +258,8 @@ export const mapSlice = createSlice({
       })
       .addCase(getWMTSOverlays.fulfilled, (state, action) => {
         state.wmtsStatus = 'succeeded';
-        state.wmtsLayers = action.payload;
+        state.wmtsLayers.push(...action.payload.layers);
+        if (!state.wmtsWorkspaces.includes(action.payload.workspace)) state.wmtsWorkspaces.push(action.payload.workspace);
       })
       .addCase(getWMTSOverlays.rejected, (state) => {
         state.wmtsStatus = 'failed';

--- a/src/UI/state/state.types.ts
+++ b/src/UI/state/state.types.ts
@@ -216,6 +216,11 @@ export enum RolesEnum {
   MODEL_MANAGER = 'model-manager',
 }
 
+export enum WMTSWorkspacesEnum {
+  SPECIES = 'species_maps',
+  IR = 'ir_maps'
+}
+
 export type UploadedModel = {
   id: string | undefined;
   title: string;

--- a/src/UI/state/state.types.ts
+++ b/src/UI/state/state.types.ts
@@ -218,7 +218,7 @@ export enum RolesEnum {
 
 export enum WMTSWorkspacesEnum {
   SPECIES = 'species_maps',
-  IR = 'ir_maps'
+  IR = 'ir_maps',
 }
 
 export type UploadedModel = {


### PR DESCRIPTION
Task was to have the Species Distribution Overlays be fetched from geoserver where IR Overlays are located as well. Changelog:

- Update `getWMTSOverlays` to retrieve by workspace as argument. 
- Implement floating overlay panel for Species distribution based on IR Overlay Panel. 
- Create base Overlay Panel section from which IR and Species Overlay Panels can spawn and thus be viewed at the same time.
