### PR TITLE
Fix: Revert page layout while ensuring map overflow containment.

### DIFF
--- a/src/UI/components/map/layers/drawerMap.tsx
+++ b/src/UI/components/map/layers/drawerMap.tsx
@@ -47,7 +47,7 @@ export default function DrawerMap() {
   );
 
   const openedMixin = (theme: any) => ({
-    maxWidth: drawerWidth,
+    width: drawerWidth,
     transition: theme.transitions.create('width', {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen,
@@ -73,9 +73,11 @@ export default function DrawerMap() {
   return (
     <Drawer
       sx={{
+        position: 'relative',
         flexShrink: 0,
         whiteSpace: 'nowrap',
         boxSizing: 'border-box',
+        zIndex: 1,
         ...(open
           ? { ...openedMixin(theme), '& .MuiDrawer-paper': openedMixin(theme) }
           : {
@@ -83,7 +85,14 @@ export default function DrawerMap() {
               '& .MuiDrawer-paper': closedMixin(theme),
             }),
       }}
-      PaperProps={{ sx: { position: 'inherit' } }}
+      PaperProps={{
+        sx: {
+          position: 'inherit',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+        },
+      }}
       variant="permanent"
       open={open}
     >
@@ -100,7 +109,9 @@ export default function DrawerMap() {
         </IconButton>
       </Box>
 
-      <List sx={{ overflowX: 'hidden', overflowY: 'auto' }}>
+      <List
+        sx={{ overflowX: 'hidden', overflowY: 'auto', flex: 1, minHeight: 0 }}
+      >
         <Divider />
         <FilterList
           sectionTitle={t('drawerMap.filtersTitle')}

--- a/src/UI/components/map/layers/irOverlayModal.tsx
+++ b/src/UI/components/map/layers/irOverlayModal.tsx
@@ -995,13 +995,14 @@ export const IROverlaysPanel: React.FC = () => {
           elevation={0}
           sx={{
             position: 'fixed',
+            bottom: isVectorPanelVisible ? `${VECTOR_PANEL_MIN_HEIGHT}px` : 0,
             left: 0,
             right: 0,
             zIndex: 1300,
+            flex: 1,
             display: 'flex',
             flexDirection: 'column',
             overflow: 'hidden',
-            bottom: isVectorPanelVisible ? `${VECTOR_PANEL_MIN_HEIGHT}px` : 0,
             maxHeight: isMinimized
               ? MOBILE_SHEET_MIN_HEIGHT
               : MOBILE_SHEET_MAX_HEIGHT,

--- a/src/UI/components/map/mapView/map-v2.tsx
+++ b/src/UI/components/map/mapView/map-v2.tsx
@@ -997,6 +997,7 @@ const MapWrapperV3: React.FC<MapWrapperV3Props> = ({ doiResolverId }) => {
       sx={{
         display: 'flex',
         flex: 1,
+        height: '100%',
         position: 'relative',
         overflow: 'hidden',
       }}

--- a/src/UI/pages/_app.tsx
+++ b/src/UI/pages/_app.tsx
@@ -34,8 +34,9 @@ function MyApp({ Component, pageProps }: AppProps) {
     // store.dispatch(getOccurrenceData());
   }, []);
   //const messages = {}; //await getMessages();
-  const { locale } = useRouter();
+  const { locale, pathname } = useRouter();
 
+  const noMarginTopPaths = ['/map', '/'];
   return (
     <>
       <Script
@@ -55,25 +56,30 @@ function MyApp({ Component, pageProps }: AppProps) {
                 <meta name="description" content="Vector Atlas" />
                 <link rel="icon" href="/Animals-Mosquito-icon.png" />
               </Head>
-              <Stack
-                direction="column"
-                sx={{ height: '100vh', width: '100vw', overflow: 'auto' }}
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  minHeight: '100vh',
+                  height: pathname === '/map' ? '100vh' : 'auto',
+                }}
               >
                 <NavBar />
                 <div
                   style={{
-                    flex: 9.5,
                     zIndex: 1,
                     display: 'flex',
-                    overflow: 'hidden',
-                    height: '100%',
-                    width: '100%',
+                    flex: 1,
+                    flexDirection: 'column',
+                    overflow: pathname === '/map' ? 'hidden' : 'visible',
+                    marginTop: !noMarginTopPaths.includes(pathname)
+                      ? '64px'
+                      : '0',
                   }}
                 >
                   <Component {...pageProps} />
                 </div>
-                {/* <Footer /> */}
-              </Stack>
+              </div>
             </UserProvider>
           </ThemeProvider>
         </Provider>

--- a/src/UI/pages/about.tsx
+++ b/src/UI/pages/about.tsx
@@ -15,7 +15,7 @@ function About(): JSX.Element {
 
   const t = useTranslations('AboutPage');
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       <main>
         <Container
           sx={{

--- a/src/UI/pages/admin.tsx
+++ b/src/UI/pages/admin.tsx
@@ -9,7 +9,7 @@ import { getMessages } from '../utils/localization';
 export default function SourcesPage(): JSX.Element {
   const t = useTranslations('AdminPage');
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       <main>
         <Container>
           <AuthWrapper role="admin">

--- a/src/UI/pages/datasets.tsx
+++ b/src/UI/pages/datasets.tsx
@@ -4,19 +4,15 @@ import ApprovalPage from '../components/admin/approval';
 
 export default function DatasetsPage(): JSX.Element {
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
-      <main>
-        <Container>
-          <AuthWrapper role="admin">
-            <div>
-              <Typography variant="h4" color="primary" sx={{ mt: 2, mb: 2 }}>
-                Datasets Approval
-              </Typography>
-              <ApprovalPage />
-            </div>
-          </AuthWrapper>
-        </Container>
-      </main>
-    </div>
+    <Container>
+      <AuthWrapper role="admin">
+        <div>
+          <Typography variant="h4" color="primary" sx={{ mt: 2, mb: 2 }}>
+            Datasets Approval
+          </Typography>
+          <ApprovalPage />
+        </div>
+      </AuthWrapper>
+    </Container>
   );
 }

--- a/src/UI/pages/editLogsViewer.tsx
+++ b/src/UI/pages/editLogsViewer.tsx
@@ -62,355 +62,353 @@ const EditLogsViewer: React.FC = () => {
   };
 
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
-      <main>
+    <main>
+      <div
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'flex-start',
+          backgroundColor: '#f3f4f6',
+          padding: '40px',
+        }}
+      >
         <div
           style={{
-            minHeight: '100vh',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'flex-start',
-            backgroundColor: '#f3f4f6',
+            width: '100%',
+            maxWidth: '1200px',
+            backgroundColor: '#fff',
+            borderRadius: '12px',
+            boxShadow: '0 4px 15px rgba(0,0,0,0.1)',
             padding: '40px',
           }}
         >
-          <div
+          <h2
             style={{
-              width: '100%',
-              maxWidth: '1200px',
-              backgroundColor: '#fff',
-              borderRadius: '12px',
-              boxShadow: '0 4px 15px rgba(0,0,0,0.1)',
-              padding: '40px',
+              textAlign: 'center',
+              fontSize: '28px',
+              fontWeight: 700,
+              marginBottom: '30px',
+              color: '#1f2937',
             }}
           >
-            <h2
+            Edit Logs
+          </h2>
+
+          <div style={{ overflowX: 'auto', borderRadius: '8px' }}>
+            <table
               style={{
+                width: '100%',
+                borderCollapse: 'collapse',
                 textAlign: 'center',
-                fontSize: '28px',
-                fontWeight: 700,
-                marginBottom: '30px',
-                color: '#1f2937',
               }}
             >
-              Edit Logs
-            </h2>
+              <thead>
+                <tr style={{ backgroundColor: '#f9fafb' }}>
+                  {['Number', 'Editor', 'Reason', 'Timestamp', 'Action'].map(
+                    (header) => (
+                      <th
+                        key={header}
+                        style={{
+                          border: '1px solid #e5e7eb',
+                          padding: '14px 18px',
+                          fontSize: '14px',
+                          fontWeight: 600,
+                          textTransform: 'uppercase',
+                          color: '#374151',
+                          verticalAlign: 'top',
+                        }}
+                      >
+                        {header}
+                      </th>
+                    )
+                  )}
+                </tr>
+              </thead>
 
-            <div style={{ overflowX: 'auto', borderRadius: '8px' }}>
-              <table
-                style={{
-                  width: '100%',
-                  borderCollapse: 'collapse',
-                  textAlign: 'center',
-                }}
-              >
-                <thead>
-                  <tr style={{ backgroundColor: '#f9fafb' }}>
-                    {['Number', 'Editor', 'Reason', 'Timestamp', 'Action'].map(
-                      (header) => (
-                        <th
-                          key={header}
+              <tbody>
+                {logs.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      style={{
+                        padding: '30px',
+                        color: '#6b7280',
+                        fontSize: '16px',
+                      }}
+                    >
+                      No logs found.
+                    </td>
+                  </tr>
+                ) : (
+                  logs.map((log, index) => {
+                    let editor: any = {};
+                    try {
+                      editor =
+                        typeof log.editor === 'string'
+                          ? JSON.parse(log.editor)
+                          : log.editor;
+                    } catch {
+                      editor = { name: 'Unknown', email: '' };
+                    }
+
+                    return (
+                      <tr
+                        key={log.id}
+                        style={{
+                          borderBottom: '1px solid #e5e7eb',
+                          transition: 'background-color 0.2s',
+                          cursor: 'pointer',
+                        }}
+                        onMouseEnter={(e) =>
+                          (e.currentTarget.style.backgroundColor = '#f3f4f6')
+                        }
+                        onMouseLeave={(e) =>
+                          (e.currentTarget.style.backgroundColor =
+                            'transparent')
+                        }
+                      >
+                        <td
                           style={{
-                            border: '1px solid #e5e7eb',
-                            padding: '14px 18px',
-                            fontSize: '14px',
-                            fontWeight: 600,
-                            textTransform: 'uppercase',
+                            padding: '12px 18px',
                             color: '#374151',
                             verticalAlign: 'top',
                           }}
                         >
-                          {header}
-                        </th>
-                      )
-                    )}
-                  </tr>
-                </thead>
-
-                <tbody>
-                  {logs.length === 0 ? (
-                    <tr>
-                      <td
-                        colSpan={5}
-                        style={{
-                          padding: '30px',
-                          color: '#6b7280',
-                          fontSize: '16px',
-                        }}
-                      >
-                        No logs found.
-                      </td>
-                    </tr>
-                  ) : (
-                    logs.map((log, index) => {
-                      let editor: any = {};
-                      try {
-                        editor =
-                          typeof log.editor === 'string'
-                            ? JSON.parse(log.editor)
-                            : log.editor;
-                      } catch {
-                        editor = { name: 'Unknown', email: '' };
-                      }
-
-                      return (
-                        <tr
-                          key={log.id}
+                          {index + 1}
+                        </td>
+                        <td
                           style={{
-                            borderBottom: '1px solid #e5e7eb',
-                            transition: 'background-color 0.2s',
-                            cursor: 'pointer',
+                            padding: '12px 18px',
+                            verticalAlign: 'top',
                           }}
-                          onMouseEnter={(e) =>
-                            (e.currentTarget.style.backgroundColor = '#f3f4f6')
-                          }
-                          onMouseLeave={(e) =>
-                            (e.currentTarget.style.backgroundColor =
-                              'transparent')
-                          }
                         >
-                          <td
-                            style={{
-                              padding: '12px 18px',
-                              color: '#374151',
-                              verticalAlign: 'top',
-                            }}
-                          >
-                            {index + 1}
-                          </td>
-                          <td
-                            style={{
-                              padding: '12px 18px',
-                              verticalAlign: 'top',
-                            }}
-                          >
-                            <div>
-                              <p
-                                style={{
-                                  fontWeight: 600,
-                                  color: '#1f2937',
-                                }}
-                              >
-                                {editor.name}
-                              </p>
-                              <p
-                                style={{
-                                  fontSize: '13px',
-                                  color: '#6b7280',
-                                }}
-                              >
-                                {editor.email}
-                              </p>
-                            </div>
-                          </td>
-                          <td
-                            style={{
-                              padding: '12px 18px',
-                              color: '#4b5563',
-                              verticalAlign: 'top',
-                            }}
-                          >
-                            {log.reasonForEdit || '—'}
-                          </td>
-                          <td
-                            style={{
-                              padding: '12px 18px',
-                              color: '#6b7280',
-                              verticalAlign: 'top',
-                            }}
-                          >
-                            {new Date(log.timestamp).toLocaleString()}
-                          </td>
-                          <td
-                            style={{
-                              padding: '12px 18px',
-                              verticalAlign: 'top',
-                            }}
-                          >
-                            <button
-                              onClick={() => openModal(log)}
+                          <div>
+                            <p
                               style={{
-                                backgroundColor: 'green',
-                                color: '#fff',
-                                padding: '8px 16px',
-                                border: 'none',
-                                borderRadius: '6px',
-                                cursor: 'pointer',
-                                fontWeight: 500,
+                                fontWeight: 600,
+                                color: '#1f2937',
                               }}
                             >
-                              View
-                            </button>
-                          </td>
-                        </tr>
-                      );
-                    })
-                  )}
-                </tbody>
-              </table>
-            </div>
+                              {editor.name}
+                            </p>
+                            <p
+                              style={{
+                                fontSize: '13px',
+                                color: '#6b7280',
+                              }}
+                            >
+                              {editor.email}
+                            </p>
+                          </div>
+                        </td>
+                        <td
+                          style={{
+                            padding: '12px 18px',
+                            color: '#4b5563',
+                            verticalAlign: 'top',
+                          }}
+                        >
+                          {log.reasonForEdit || '—'}
+                        </td>
+                        <td
+                          style={{
+                            padding: '12px 18px',
+                            color: '#6b7280',
+                            verticalAlign: 'top',
+                          }}
+                        >
+                          {new Date(log.timestamp).toLocaleString()}
+                        </td>
+                        <td
+                          style={{
+                            padding: '12px 18px',
+                            verticalAlign: 'top',
+                          }}
+                        >
+                          <button
+                            onClick={() => openModal(log)}
+                            style={{
+                              backgroundColor: 'green',
+                              color: '#fff',
+                              padding: '8px 16px',
+                              border: 'none',
+                              borderRadius: '6px',
+                              cursor: 'pointer',
+                              fontWeight: 500,
+                            }}
+                          >
+                            View
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
           </div>
+        </div>
 
-          {/* Modal */}
-          {selectedLog && diffData && (
+        {/* Modal */}
+        {selectedLog && diffData && (
+          <div
+            style={{
+              position: 'fixed',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '100%',
+              backgroundColor: 'rgba(0,0,0,0.5)',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              zIndex: 1000,
+              padding: '20px',
+            }}
+          >
             <div
               style={{
-                position: 'fixed',
-                top: 0,
-                left: 0,
-                width: '100%',
-                height: '100%',
-                backgroundColor: 'rgba(0,0,0,0.5)',
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                zIndex: 1000,
-                padding: '20px',
+                backgroundColor: '#fff',
+                borderRadius: '10px',
+                width: '90%',
+                maxWidth: '900px',
+                padding: '30px',
+                maxHeight: '85vh',
+                overflowY: 'auto',
+                boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
               }}
             >
-              <div
+              <h3
                 style={{
-                  backgroundColor: '#fff',
-                  borderRadius: '10px',
-                  width: '90%',
-                  maxWidth: '900px',
-                  padding: '30px',
-                  maxHeight: '85vh',
-                  overflowY: 'auto',
-                  boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
+                  textAlign: 'center',
+                  fontSize: '20px',
+                  fontWeight: 600,
+                  marginBottom: '20px',
+                  color: '#1f2937',
                 }}
               >
-                <h3
+                Data Differences
+              </h3>
+
+              {Object.keys(diffData).length === 0 ? (
+                <p style={{ textAlign: 'center', color: '#6b7280' }}>
+                  No differences found.
+                </p>
+              ) : (
+                <table
                   style={{
-                    textAlign: 'center',
-                    fontSize: '20px',
-                    fontWeight: 600,
+                    width: '100%',
+                    borderCollapse: 'collapse',
+                    fontSize: '14px',
                     marginBottom: '20px',
-                    color: '#1f2937',
                   }}
                 >
-                  Data Differences
-                </h3>
-
-                {Object.keys(diffData).length === 0 ? (
-                  <p style={{ textAlign: 'center', color: '#6b7280' }}>
-                    No differences found.
-                  </p>
-                ) : (
-                  <table
-                    style={{
-                      width: '100%',
-                      borderCollapse: 'collapse',
-                      fontSize: '14px',
-                      marginBottom: '20px',
-                    }}
-                  >
-                    <thead>
-                      <tr style={{ backgroundColor: '#f9fafb' }}>
-                        <th
+                  <thead>
+                    <tr style={{ backgroundColor: '#f9fafb' }}>
+                      <th
+                        style={{
+                          border: '1px solid #e5e7eb',
+                          padding: '10px',
+                          textAlign: 'left',
+                          fontWeight: 600,
+                          verticalAlign: 'top',
+                        }}
+                      >
+                        Field
+                      </th>
+                      <th
+                        style={{
+                          border: '1px solid #e5e7eb',
+                          padding: '10px',
+                          textAlign: 'left',
+                          color: '#dc2626',
+                          verticalAlign: 'top',
+                        }}
+                      >
+                        Old Value
+                      </th>
+                      <th
+                        style={{
+                          border: '1px solid #e5e7eb',
+                          padding: '10px',
+                          textAlign: 'left',
+                          color: '#16a34a',
+                          verticalAlign: 'top',
+                        }}
+                      >
+                        New Value
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(diffData).map(([key, val]) => (
+                      <tr key={key}>
+                        <td
                           style={{
                             border: '1px solid #e5e7eb',
                             padding: '10px',
-                            textAlign: 'left',
-                            fontWeight: 600,
+                            fontWeight: 500,
+                            color: '#374151',
                             verticalAlign: 'top',
                           }}
                         >
-                          Field
-                        </th>
-                        <th
+                          {key}
+                        </td>
+                        <td
                           style={{
                             border: '1px solid #e5e7eb',
                             padding: '10px',
-                            textAlign: 'left',
                             color: '#dc2626',
+                            wordBreak: 'break-word',
                             verticalAlign: 'top',
                           }}
                         >
-                          Old Value
-                        </th>
-                        <th
+                          {JSON.stringify(val.old, null, 2)}
+                        </td>
+                        <td
                           style={{
                             border: '1px solid #e5e7eb',
                             padding: '10px',
-                            textAlign: 'left',
                             color: '#16a34a',
+                            wordBreak: 'break-word',
                             verticalAlign: 'top',
                           }}
                         >
-                          New Value
-                        </th>
+                          {JSON.stringify(val.new, null, 2)}
+                        </td>
                       </tr>
-                    </thead>
-                    <tbody>
-                      {Object.entries(diffData).map(([key, val]) => (
-                        <tr key={key}>
-                          <td
-                            style={{
-                              border: '1px solid #e5e7eb',
-                              padding: '10px',
-                              fontWeight: 500,
-                              color: '#374151',
-                              verticalAlign: 'top',
-                            }}
-                          >
-                            {key}
-                          </td>
-                          <td
-                            style={{
-                              border: '1px solid #e5e7eb',
-                              padding: '10px',
-                              color: '#dc2626',
-                              wordBreak: 'break-word',
-                              verticalAlign: 'top',
-                            }}
-                          >
-                            {JSON.stringify(val.old, null, 2)}
-                          </td>
-                          <td
-                            style={{
-                              border: '1px solid #e5e7eb',
-                              padding: '10px',
-                              color: '#16a34a',
-                              wordBreak: 'break-word',
-                              verticalAlign: 'top',
-                            }}
-                          >
-                            {JSON.stringify(val.new, null, 2)}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                )}
+                    ))}
+                  </tbody>
+                </table>
+              )}
 
-                <div style={{ textAlign: 'right' }}>
-                  <button
-                    onClick={closeModal}
-                    style={{
-                      backgroundColor: 'green',
-                      color: '#fff',
-                      padding: '8px 16px',
-                      borderRadius: '6px',
-                      border: 'none',
-                      cursor: 'pointer',
-                    }}
-                    onMouseEnter={(e) =>
-                      (e.currentTarget.style.backgroundColor = 'green')
-                    }
-                    onMouseLeave={(e) =>
-                      (e.currentTarget.style.backgroundColor = 'green')
-                    }
-                  >
-                    Close
-                  </button>
-                </div>
+              <div style={{ textAlign: 'right' }}>
+                <button
+                  onClick={closeModal}
+                  style={{
+                    backgroundColor: 'green',
+                    color: '#fff',
+                    padding: '8px 16px',
+                    borderRadius: '6px',
+                    border: 'none',
+                    cursor: 'pointer',
+                  }}
+                  onMouseEnter={(e) =>
+                    (e.currentTarget.style.backgroundColor = 'green')
+                  }
+                  onMouseLeave={(e) =>
+                    (e.currentTarget.style.backgroundColor = 'green')
+                  }
+                >
+                  Close
+                </button>
               </div>
             </div>
-          )}
-        </div>
-      </main>
-    </div>
+          </div>
+        )}
+      </div>
+    </main>
   );
 };
 

--- a/src/UI/pages/editPointData.tsx
+++ b/src/UI/pages/editPointData.tsx
@@ -318,207 +318,195 @@ const EditPointData: React.FC = () => {
   };
 
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
-      <main>
-        <Container
-          sx={{
-            padding: '10px',
-            maxWidth: '75%',
-          }}
-        >
-          <AuthWrapper role={RolesEnum.EDITOR}>
-            <>
-              <Box sx={{ maxWidth: 800, margin: 'auto', padding: 4 }}>
-                <Typography variant="h4" gutterBottom>
-                  Edit Point Data
-                </Typography>
+    <main>
+      <Container
+        sx={{
+          padding: '10px',
+          maxWidth: '75%',
+        }}
+      >
+        <AuthWrapper role={RolesEnum.EDITOR}>
+          <>
+            <Box sx={{ maxWidth: 800, margin: 'auto', padding: 4 }}>
+              <Typography variant="h4" gutterBottom>
+                Edit Point Data
+              </Typography>
 
-                {/* Toggle between Occurrence or Source */}
-                <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
-                  <Button
-                    variant={mode === 'occurrence' ? 'contained' : 'outlined'}
-                    onClick={() => setMode('occurrence')}
-                  >
-                    By Occurrence ID
-                  </Button>
-                  <Button
-                    variant={mode === 'source' ? 'contained' : 'outlined'}
-                    onClick={() => setMode('source')}
-                  >
-                    By Source ID
-                  </Button>
-                  <Button
-                    variant={mode === 'source' ? 'contained' : 'outlined'}
-                    onClick={handleViewLogs}
-                  >
-                    See Logs
-                  </Button>
-                </Box>
+              {/* Toggle between Occurrence or Source */}
+              <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
+                <Button
+                  variant={mode === 'occurrence' ? 'contained' : 'outlined'}
+                  onClick={() => setMode('occurrence')}
+                >
+                  By Occurrence ID
+                </Button>
+                <Button
+                  variant={mode === 'source' ? 'contained' : 'outlined'}
+                  onClick={() => setMode('source')}
+                >
+                  By Source ID
+                </Button>
+                <Button
+                  variant={mode === 'source' ? 'contained' : 'outlined'}
+                  onClick={handleViewLogs}
+                >
+                  See Logs
+                </Button>
+              </Box>
 
-                {/* MODE 1: Occurrence */}
-                {mode === 'occurrence' && (
-                  <>
-                    <h4>
-                      <span style={{ color: 'green' }}>Source Id:</span>{' '}
-                      {sourceId}
-                    </h4>
-                    <Box
-                      sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 2 }}
-                    >
-                      <TextField
-                        label="Occurrence ID"
-                        value={occurrenceId}
-                        onChange={(e) => setOccurrenceId(e.target.value)}
-                        fullWidth
-                        sx={{ flex: 1, minWidth: 250 }}
-                      />
-
-                      <Autocomplete<EntityType>
-                        options={ENTITY_OPTIONS}
-                        value={entityType}
-                        onChange={(_: any, newValue: any) =>
-                          setEntityType(newValue)
-                        }
-                        renderInput={(params: any) => (
-                          <TextField
-                            {...params}
-                            label="Select Dataset Section"
-                            fullWidth
-                          />
-                        )}
-                        sx={{ flex: 1, minWidth: 250 }}
-                      />
-
-                      <Button
-                        variant="contained"
-                        onClick={fetchDataByOccurrence}
-                        disabled={loading}
-                      >
-                        {loading ? (
-                          <CircularProgress size={24} />
-                        ) : (
-                          'Fetch Data'
-                        )}
-                      </Button>
-                    </Box>
-                  </>
-                )}
-
-                {/* MODE 2: Source */}
-                {mode === 'source' && (
+              {/* MODE 1: Occurrence */}
+              {mode === 'occurrence' && (
+                <>
+                  <h4>
+                    <span style={{ color: 'green' }}>Source Id:</span>{' '}
+                    {sourceId}
+                  </h4>
                   <Box
                     sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 2 }}
                   >
                     <TextField
-                      label="Source ID"
-                      value={sourceId}
-                      onChange={(e: any) => setSourceId(e.target.value)}
+                      label="Occurrence ID"
+                      value={occurrenceId}
+                      onChange={(e) => setOccurrenceId(e.target.value)}
                       fullWidth
+                      sx={{ flex: 1, minWidth: 250 }}
+                    />
+
+                    <Autocomplete<EntityType>
+                      options={ENTITY_OPTIONS}
+                      value={entityType}
+                      onChange={(_: any, newValue: any) =>
+                        setEntityType(newValue)
+                      }
+                      renderInput={(params: any) => (
+                        <TextField
+                          {...params}
+                          label="Select Dataset Section"
+                          fullWidth
+                        />
+                      )}
                       sx={{ flex: 1, minWidth: 250 }}
                     />
 
                     <Button
                       variant="contained"
-                      onClick={fetchDataBySource}
+                      onClick={fetchDataByOccurrence}
                       disabled={loading}
                     >
-                      {loading ? (
-                        <CircularProgress size={24} />
+                      {loading ? <CircularProgress size={24} /> : 'Fetch Data'}
+                    </Button>
+                  </Box>
+                </>
+              )}
+
+              {/* MODE 2: Source */}
+              {mode === 'source' && (
+                <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 2 }}>
+                  <TextField
+                    label="Source ID"
+                    value={sourceId}
+                    onChange={(e: any) => setSourceId(e.target.value)}
+                    fullWidth
+                    sx={{ flex: 1, minWidth: 250 }}
+                  />
+
+                  <Button
+                    variant="contained"
+                    onClick={fetchDataBySource}
+                    disabled={loading}
+                  >
+                    {loading ? <CircularProgress size={24} /> : 'Fetch Records'}
+                  </Button>
+                </Box>
+              )}
+
+              {/* Source record list */}
+              {mode === 'source' && sourceRecords.length > 0 && (
+                <Box sx={{ mt: 4 }}>
+                  <Typography variant="h5" gutterBottom>
+                    Select a Record to Edit
+                  </Typography>
+                  {sourceRecords.map((rec: any, idx: any) => (
+                    <Box
+                      key={rec.id || idx}
+                      sx={{
+                        border: '1px solid #ddd',
+                        borderRadius: 2,
+                        p: 2,
+                        mb: 2,
+                      }}
+                    >
+                      <Typography variant="subtitle1">
+                        Record {idx + 1} (ID: {rec.id})
+                      </Typography>
+                      <Button
+                        variant="outlined"
+                        sx={{ mt: 1 }}
+                        onClick={() => handleSelectRecord(rec)}
+                      >
+                        Edit This Record
+                      </Button>
+                    </Box>
+                  ))}
+                </Box>
+              )}
+
+              {/* Edit Form */}
+              {data && mode === 'occurrence' && (
+                <Box sx={{ mt: 4 }}>
+                  <Typography variant="h5" gutterBottom>
+                    Edit Fields
+                  </Typography>
+
+                  {Array.isArray(data)
+                    ? data.map((record, index) => (
+                        <Box
+                          key={String(record['id']) || index}
+                          sx={{
+                            border: '1px solid #ddd',
+                            borderRadius: 2,
+                            p: 2,
+                            mb: 2,
+                          }}
+                        >
+                          <Typography variant="h6" gutterBottom>
+                            Record {index + 1}
+                          </Typography>
+                          {Object.entries(record).map(([key, value]) =>
+                            renderField(key, value, index)
+                          )}
+                        </Box>
+                      ))
+                    : Object.entries(data).map(([key, value]) =>
+                        renderField(key, value)
+                      )}
+
+                  <Box
+                    sx={{
+                      mt: 2,
+                      display: 'flex',
+                      justifyContent: 'flex-end',
+                    }}
+                  >
+                    <Button
+                      variant="contained"
+                      onClick={handleSave}
+                      disabled={saving || !data || !entityType}
+                    >
+                      {saving ? (
+                        <CircularProgress size={24} color="inherit" />
                       ) : (
-                        'Fetch Records'
+                        'Save Changes'
                       )}
                     </Button>
                   </Box>
-                )}
-
-                {/* Source record list */}
-                {mode === 'source' && sourceRecords.length > 0 && (
-                  <Box sx={{ mt: 4 }}>
-                    <Typography variant="h5" gutterBottom>
-                      Select a Record to Edit
-                    </Typography>
-                    {sourceRecords.map((rec: any, idx: any) => (
-                      <Box
-                        key={rec.id || idx}
-                        sx={{
-                          border: '1px solid #ddd',
-                          borderRadius: 2,
-                          p: 2,
-                          mb: 2,
-                        }}
-                      >
-                        <Typography variant="subtitle1">
-                          Record {idx + 1} (ID: {rec.id})
-                        </Typography>
-                        <Button
-                          variant="outlined"
-                          sx={{ mt: 1 }}
-                          onClick={() => handleSelectRecord(rec)}
-                        >
-                          Edit This Record
-                        </Button>
-                      </Box>
-                    ))}
-                  </Box>
-                )}
-
-                {/* Edit Form */}
-                {data && mode === 'occurrence' && (
-                  <Box sx={{ mt: 4 }}>
-                    <Typography variant="h5" gutterBottom>
-                      Edit Fields
-                    </Typography>
-
-                    {Array.isArray(data)
-                      ? data.map((record, index) => (
-                          <Box
-                            key={String(record['id']) || index}
-                            sx={{
-                              border: '1px solid #ddd',
-                              borderRadius: 2,
-                              p: 2,
-                              mb: 2,
-                            }}
-                          >
-                            <Typography variant="h6" gutterBottom>
-                              Record {index + 1}
-                            </Typography>
-                            {Object.entries(record).map(([key, value]) =>
-                              renderField(key, value, index)
-                            )}
-                          </Box>
-                        ))
-                      : Object.entries(data).map(([key, value]) =>
-                          renderField(key, value)
-                        )}
-
-                    <Box
-                      sx={{
-                        mt: 2,
-                        display: 'flex',
-                        justifyContent: 'flex-end',
-                      }}
-                    >
-                      <Button
-                        variant="contained"
-                        onClick={handleSave}
-                        disabled={saving || !data || !entityType}
-                      >
-                        {saving ? (
-                          <CircularProgress size={24} color="inherit" />
-                        ) : (
-                          'Save Changes'
-                        )}
-                      </Button>
-                    </Box>
-                  </Box>
-                )}
-              </Box>
-            </>
-          </AuthWrapper>
-        </Container>
-      </main>
-    </div>
+                </Box>
+              )}
+            </Box>
+          </>
+        </AuthWrapper>
+      </Container>
+    </main>
   );
 };
 

--- a/src/UI/pages/hub.tsx
+++ b/src/UI/pages/hub.tsx
@@ -10,7 +10,7 @@ import { useTranslations } from 'next-intl';
 function DataHub() {
   const t = useTranslations('DataHubPage');
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       <main>
         <Container
           sx={{

--- a/src/UI/pages/index.tsx
+++ b/src/UI/pages/index.tsx
@@ -25,7 +25,7 @@ function Home(): JSX.Element {
   const t = useTranslations('HomePage');
 
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       <main>
         <Banner />
         <Container

--- a/src/UI/pages/model_upload.tsx
+++ b/src/UI/pages/model_upload.tsx
@@ -10,7 +10,7 @@ import { useTranslations } from 'next-intl';
 function ModelUploadPage() {
   const t = useTranslations('UploadedModelPage');
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       <main>
         <Container
           sx={{

--- a/src/UI/pages/new_source.tsx
+++ b/src/UI/pages/new_source.tsx
@@ -8,7 +8,7 @@ import { GetServerSidePropsContext } from 'next';
 function NewSource(): JSX.Element {
   return (
     <>
-      <div style={{ flex: 1, overflowY: 'auto' }}>
+      <div>
         <main>
           <Container
             maxWidth={false}

--- a/src/UI/pages/reupload.tsx
+++ b/src/UI/pages/reupload.tsx
@@ -9,7 +9,7 @@ const ReUploadDatasetPage = () => {
   const datasetId = (router.query.id as string) || undefined;
   return (
     <>
-      <div style={{ flex: 1, overflowY: 'auto' }}>
+      <div>
         <main>
           <Container
             maxWidth={false}

--- a/src/UI/pages/review.tsx
+++ b/src/UI/pages/review.tsx
@@ -12,7 +12,7 @@ function Review() {
   const dataset = router.query.dataset as string;
 
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       <Container>
         <SectionPanel title="Data review">
           <AuthWrapper role={RolesEnum.REVIEWER}>

--- a/src/UI/pages/sendEmail.tsx
+++ b/src/UI/pages/sendEmail.tsx
@@ -23,7 +23,7 @@ const SendEmail = () => {
   };
 
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       <button onClick={handleOpenPopup}>Open Email Form</button>
 
       {/* Reusable EmailPopup component */}

--- a/src/UI/pages/sources.tsx
+++ b/src/UI/pages/sources.tsx
@@ -22,7 +22,7 @@ export default function SourcesPage(): JSX.Element {
   }, [dispatch]);
 
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       <main>
         <Container
           sx={{

--- a/src/UI/pages/species.tsx
+++ b/src/UI/pages/species.tsx
@@ -17,7 +17,7 @@ export default function SourcesPage(): JSX.Element {
   }, [dispatch]);
 
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       <main>
         <Container
           maxWidth={false}

--- a/src/UI/pages/translations-edit.tsx
+++ b/src/UI/pages/translations-edit.tsx
@@ -58,7 +58,7 @@ function TranslationsEditPage() {
     setLabels(labels);
   }, [LabelsEn]);
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       <main>
         <Container
           sx={{

--- a/src/UI/pages/upload.tsx
+++ b/src/UI/pages/upload.tsx
@@ -29,7 +29,7 @@ function Upload() {
   }, [dispatch]);
 
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       <main>
         <Container
           sx={{

--- a/src/UI/pages/user_settings.tsx
+++ b/src/UI/pages/user_settings.tsx
@@ -10,7 +10,7 @@ import { useTranslations } from 'next-intl';
 function UserSettings() {
   const t = useTranslations('UserSettings');
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       <main>
         <Container
           sx={{


### PR DESCRIPTION
This changes reverts the _app layout and its pages to the original layout in which the entire page can overflow. 

Changelog:

- Overflow containment changes have been added to the `src/UI/pages/_app.tsx`,  `src/components/map/layers/drawerMap.tsx` and `src/UI/components/map/mapView/map-v2.tsx` to ensure that the map section itself does not overflow when, for instance, the drawer overflows when the filter panel is opened.
- Change in `src/UI/components/map/layers/irOverlayModal.tsx`  is only for fixing the mobile layout issue by ensuring the panel is anchored to the bottom.
- The rest of the file changes simply remove the snippet `style={{ flex: 1, overflowY: 'auto' }}` from the file reverting their layout to their original form.