### PR TITLE
Fix/template download corruption

### DIFF
--- a/src/API/src/ingest/ingest.controller.ts
+++ b/src/API/src/ingest/ingest.controller.ts
@@ -5,11 +5,12 @@ import {
   HttpException,
   Post,
   Query,
-  Res,
   UploadedFile,
   UseGuards,
   UseInterceptors,
   Logger,
+  StreamableFile,
+  NotFoundException,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -23,6 +24,8 @@ import { transformHeaderRow } from 'src/utils';
 import { ValidationService } from 'src/validation/validation.service';
 import { IngestService } from './ingest.service';
 import * as path from 'path';
+import { createReadStream } from 'fs';
+import { stat } from 'fs/promises';
 
 @Controller('ingest')
 export class IngestController {
@@ -118,29 +121,32 @@ export class IngestController {
   }
 
   @Get('downloadTemplate')
-  downloadTemplate(
-    @Res() res,
+  async downloadTemplate(
     @Query('type') type: string,
     @Query('source') source: string,
   ) {
     const extension = 'xlsx'; // ✅ All templates are now Excel
 
+    const fileName = `${type}.${extension}`;
+
     const filePath = path.join(
       config.get('dataTemplatesFolder'),
       source,
-      `${type}.xlsx`,
+      fileName,
     );
 
-    return res.download(filePath, `${type}.${extension}`, (err) => {
-      if (err) {
-        this.logger.error(`Template not found: ${filePath}`);
-        if (!res.headersSent) {
-          res.status(404).json({
-            statusCode: 404,
-            message: `Template not found: ${type}.${extension}`,
-          });
-        }
-      }
+    // Check if file exists
+    try {
+      await stat(filePath);
+    } catch (e) {
+      this.logger.error(`Template not found: ${filePath}`);
+      throw new NotFoundException(`Template not found: ${fileName}`);
+    }
+
+    const fileStream = createReadStream(filePath);
+
+    return new StreamableFile(fileStream, {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     });
   }
 }

--- a/src/UI/api/api.ts
+++ b/src/UI/api/api.ts
@@ -533,9 +533,14 @@ export const downloadTemplateFile = async (
   dataType: string,
   dataSource: string
 ) => {
-  const res = await axios.get(
-    `${apiUrl}ingest/downloadTemplate?type=${dataType}&source=${dataSource}`
-  );
+  // const res = await axios.get(
+  //   `${apiUrl}ingest/downloadTemplate?type=${dataType}&source=${dataSource}`,
+  // );
+  const res = await axios({
+    url: `${apiUrl}ingest/downloadTemplate?type=${dataType}&source=${dataSource}`,
+    method: 'GET',
+    responseType: 'blob',
+  });
   return download(res.data, `${dataSource}_${dataType}_template.xlsx`);
 };
 

--- a/src/UI/public/messages/en.json
+++ b/src/UI/public/messages/en.json
@@ -108,7 +108,7 @@
       "ingestionProgress": "Ingestion Progress",
       "doi": "Dataset DOI",
       "submit": "Submit"
-    }, 
+    },
     "actions": {
       "open": "Open",
       "assignPrimaryReviewers": "Assign Primary Reviewers",
@@ -161,8 +161,8 @@
       "validDataset": "Dataset is valid",
       "datasetHasErrors": "Dataset contains errors",
       "aggregateValidationErrors": "Validation Entire Dataset",
-      "groupErrorsBy": "Group Errors By", 
-      "errorType": "Error Type", 
+      "groupErrorsBy": "Group Errors By",
+      "errorType": "Error Type",
       "row": "Row",
       "errors": {
         "attachFile": "You must attach a file"
@@ -447,8 +447,8 @@
     "template": {
       "occurrence": "Occurrence",
       "occurenceBionomics": "Occurrence & Bionomics",
-      "occurrenceIR": "Occurrence & Insecticide Resistance Bioassays",
-      "occurrenceBionomicsIR": "Occurrence, Bionomics & Insecticide Resistance Bioassays"
+      "occurrenceIR": "Occurrence & Insecticide Resistance",
+      "occurrenceBionomicsIR": "Occurrence, Bionomics & Insecticide Resistance"
     }
   },
   "NewsPage": {
@@ -491,38 +491,37 @@
     }
   },
   "AboutPage": {
-  "sectionHeaders": {
-    "about": "About",
-    "team": "The Team",
-    "contact": "Contact",
-    "partners": "Partners"
-  },
-  "contact": {
-    "projectTeam": "project team",
-    "email": "Email",
-    "getInTouch": "Get in touch with our dedicated team for any inquiries or collaboration opportunities"
-  },
-  "fieldStation": {
-    "tel": "Tel",
-    "fax": "Fax",
-    "location": "Location",
-    "seeLocation": "See Location"
-  },
-  "header": {
-    "paragraph1": "Maps are powerful tools. They can illustrate the distribution of mosquito vector species known to transmit some of the world's most debilitating diseases and highlight where these species are no longer susceptible to the insecticides used as their primary method of control.",
-    "paragraph2": "All evidence-based maps rely on field data collected in a myriad of different ways by multiple data collectors for a wide variety of purposes. In isolation, these data are able to answer the questions they were collected to address, but when combined, their value multiplies.",
-    "paragraph3": "The Vector Atlas is an international project dedicated to synthesising complex vector data into intuitive mapped surfaces to support vector control decision making. At its core is the Vector Atlas Data Base (VADB), built over the past three years and continuing to expand. The VADB combines African vector occurrence, bionomics and insecticide resistance data alongside human behaviour, local environment and community information.",
-    "paragraph4": "It provides a 'one stop shop' of relatable and cross-referenced data access and underpins a comprehensive suite of vector maps, including species suitability, phenotypic insecticide resistance and relative abundance. All curated data and modelled surfaces are available for download via the map page on this platform. Working closely with expert vector teams in Burkina Faso, Côte d’Ivoire, the Democratic Republic of the Congo, Nigeria, Senegal and Uganda, we are bringing spatial modelling to the core of malaria vector control decisions.",
-    "paragraph5": "The Vector Atlas is a University of Oxford, International Centre of Insect Physiology and Ecology (icipe) and The Kids (Australia) initiative, working alongside the Malaria Atlas Project and funded by the Gates Foundation.",
-    "paragraph6": "We are always interested in receiving feedback to continue developing the Vector Atlas resources shared via this platform. If you have any comments, questions or suggestions, please contact us via email."
-  },
-  "office": {
-    "address": "Address",
-    "tel": "Tel",
-    "fax": "Fax",
-    "email": "vectoratlas@icipe.org"
-  }
-
+    "sectionHeaders": {
+      "about": "About",
+      "team": "The Team",
+      "contact": "Contact",
+      "partners": "Partners"
+    },
+    "contact": {
+      "projectTeam": "project team",
+      "email": "Email",
+      "getInTouch": "Get in touch with our dedicated team for any inquiries or collaboration opportunities"
+    },
+    "fieldStation": {
+      "tel": "Tel",
+      "fax": "Fax",
+      "location": "Location",
+      "seeLocation": "See Location"
+    },
+    "header": {
+      "paragraph1": "Maps are powerful tools. They can illustrate the distribution of mosquito vector species known to transmit some of the world's most debilitating diseases and highlight where these species are no longer susceptible to the insecticides used as their primary method of control.",
+      "paragraph2": "All evidence-based maps rely on field data collected in a myriad of different ways by multiple data collectors for a wide variety of purposes. In isolation, these data are able to answer the questions they were collected to address, but when combined, their value multiplies.",
+      "paragraph3": "The Vector Atlas is an international project dedicated to synthesising complex vector data into intuitive mapped surfaces to support vector control decision making. At its core is the Vector Atlas Data Base (VADB), built over the past three years and continuing to expand. The VADB combines African vector occurrence, bionomics and insecticide resistance data alongside human behaviour, local environment and community information.",
+      "paragraph4": "It provides a 'one stop shop' of relatable and cross-referenced data access and underpins a comprehensive suite of vector maps, including species suitability, phenotypic insecticide resistance and relative abundance. All curated data and modelled surfaces are available for download via the map page on this platform. Working closely with expert vector teams in Burkina Faso, Côte d’Ivoire, the Democratic Republic of the Congo, Nigeria, Senegal and Uganda, we are bringing spatial modelling to the core of malaria vector control decisions.",
+      "paragraph5": "The Vector Atlas is a University of Oxford, International Centre of Insect Physiology and Ecology (icipe) and The Kids (Australia) initiative, working alongside the Malaria Atlas Project and funded by the Gates Foundation.",
+      "paragraph6": "We are always interested in receiving feedback to continue developing the Vector Atlas resources shared via this platform. If you have any comments, questions or suggestions, please contact us via email."
+    },
+    "office": {
+      "address": "Address",
+      "tel": "Tel",
+      "fax": "Fax",
+      "email": "vectoratlas@icipe.org"
+    }
   },
   "SpeciesPage": {
     "title": "Species List",

--- a/src/UI/public/messages/fr.json
+++ b/src/UI/public/messages/fr.json
@@ -101,11 +101,11 @@
       "validationEndRow": "Ligne de fin de validation",
       "errorRows": "Lignes contenant des erreurs",
       "errors": "Erreurs de validation",
-      "totalRows": "Total des lignes",  
+      "totalRows": "Total des lignes",
       "ingestionStatus": "Statut d'ingestion",
       "ingestionErrors": "Erreurs d'ingestion",
       "totalIngestedRows": "Nombre total de lignes ingérées",
-      "ingestionProgress": "Progression de l'ingestion",  
+      "ingestionProgress": "Progression de l'ingestion",
       "doi": "Ensemble de données DOI",
       "submit": "Soumettre"
     },
@@ -160,9 +160,9 @@
       "attachDataset": "Joindre un ensemble de données",
       "validDataset": "L'ensemble de données est valide",
       "datasetHasErrors": "L'ensemble de données contient des erreurs",
-      "aggregateValidationErrors": "Validation de l'ensemble des données", 
-      "groupErrorsBy": "Erreurs de groupe par", 
-      "errorType": "Type d'erreur", 
+      "aggregateValidationErrors": "Validation de l'ensemble des données",
+      "groupErrorsBy": "Erreurs de groupe par",
+      "errorType": "Type d'erreur",
       "row": "Rangée",
       "errors": {
         "attachFile": "Vous devez joindre un fichier"
@@ -441,8 +441,8 @@
     "template": {
       "occurrence": "Occurrence",
       "occurenceBionomics": "Occurrence et bionomique",
-      "occurrenceIR": "Occurrence et résistance aux insecticides bioessays",
-      "occurrenceBionomicsIR": "Occurrence, bionomique et résistance aux insecticides bioessays"
+      "occurrenceIR": "Occurrence et résistance aux insecticides",
+      "occurrenceBionomicsIR": "Occurrence, bionomique et résistance aux insecticides"
     }
   },
   "NewsPage": {


### PR DESCRIPTION
Changelog:

- `src/API/src/ingest/ingest.controller.ts` - Adjust download route inside ingest to use nestjs' idiomatic approach for downloading files in addition to making the route asynchronous.
- `src/UI/api/api.ts` - Add the property `responseType` to the axios download configuration of the xlsx files to prevent wrong encoding.
- The rest changes the labels of the data template downloads (removing the word Bioassay).