### PR TITLE
Fix/remove duplicate reference id sequences

### DIFF
--- a/src/API/.envrc.template
+++ b/src/API/.envrc.template
@@ -33,6 +33,8 @@ export DATACITE_PREFIX='10.82746'
 export DOI_PUBLISHER='International Centre of Insect Physiology and Ecology'
 export AZURE_CONTAINER_NAME=vectoratlas
 export MAX_UPLOAD_SIZE=100000 #onekb=1000 100MB
+export FILE_STORAGE_TYPE=Local # one of Azure or Local
 
-export DATA_TEMPLATES_FOLDER=''
-export FULL_OCCURRENCE_DATA_FOLDER=''
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+export DATA_TEMPLATES_FOLDER="$SCRIPT_DIR/templates/Vector Atlas"
+export FULL_OCCURRENCE_DATA_FOLDER="$SCRIPT_DIR/../OccurrenceGeoJob/.tmp/target" # Set to value of TARGET_DIRECTORY of OccurrenceGeoJob. Ensure job has been ran first.

--- a/src/API/src/db/migrations/1778735811063-uploaded-dataset-ingestion-tracking-fields.ts
+++ b/src/API/src/db/migrations/1778735811063-uploaded-dataset-ingestion-tracking-fields.ts
@@ -1,29 +1,28 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class UploadedDatasetIngestionTrackingFields1778735811063
-  implements MigrationInterface
-{
+  implements MigrationInterface {
   name = 'UploadedDatasetIngestionTrackingFields1778735811063';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       ALTER TABLE "uploaded_dataset"
-      ADD "ingestion_status" character varying
+      ADD COLUMN IF NOT EXISTS "ingestion_status" character varying
     `);
 
     await queryRunner.query(`
       ALTER TABLE "uploaded_dataset"
-      ADD "ingestion_errors" text
+      ADD COLUMN IF NOT EXISTS "ingestion_errors" text
     `);
 
     await queryRunner.query(`
       ALTER TABLE "uploaded_dataset"
-      ADD "total_ingested_rows" integer DEFAULT '0'
+      ADD COLUMN IF NOT EXISTS "total_ingested_rows" integer DEFAULT '0'
     `);
 
     await queryRunner.query(`
       ALTER TABLE "uploaded_dataset"
-      ADD "ingestion_progress" double precision DEFAULT '0'
+      ADD COLUMN IF NOT EXISTS "ingestion_progress" double precision DEFAULT '0'
     `);
 
     // DO NOT TOUCH reference PRIMARY KEY
@@ -32,22 +31,22 @@ export class UploadedDatasetIngestionTrackingFields1778735811063
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       ALTER TABLE "uploaded_dataset"
-      DROP COLUMN "ingestion_progress"
+      DROP COLUMN IF EXISTS "ingestion_progress"
     `);
 
     await queryRunner.query(`
       ALTER TABLE "uploaded_dataset"
-      DROP COLUMN "total_ingested_rows"
+      DROP COLUMN IF EXISTS "total_ingested_rows"
     `);
 
     await queryRunner.query(`
       ALTER TABLE "uploaded_dataset"
-      DROP COLUMN "ingestion_errors"
+      DROP COLUMN IF EXISTS "ingestion_errors"
     `);
 
     await queryRunner.query(`
       ALTER TABLE "uploaded_dataset"
-      DROP COLUMN "ingestion_status"
+      DROP COLUMN IF EXISTS "ingestion_status"
     `);
   }
 }

--- a/src/API/src/db/migrations/1784196181628-fix-reference-sequence-duplicate.ts
+++ b/src/API/src/db/migrations/1784196181628-fix-reference-sequence-duplicate.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FixReferenceSequenceDuplicate1784196181628 implements MigrationInterface {
+  name = 'FixReferenceSequenceDuplicate1784196181628'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP SEQUENCE IF EXISTS "reference_id_seq"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE SEQUENCE IF NOT EXISTS "reference_id_seq" INCREMENT 1 START 1 MINVALUE 1 OWNED BY "reference"."num_id"`);
+  }
+}

--- a/src/OccurrenceGeoJob/.envrc.template
+++ b/src/OccurrenceGeoJob/.envrc.template
@@ -2,7 +2,7 @@
 export PGPORT=5432
 export PGUSER=postgres
 export PGPASSWORD=postgrespass
-export PDATABASE=mva
+export PGDATABASE=mva
 export PGHOST=127.0.0.1
 
 # Logging Configuration


### PR DESCRIPTION
On a fresh database instance, the column `num_id` in `references` table contained duplicate sequences:

- `reference_id_seq` - Created manually in 2022 with migration `reference_numeric_id`.
- `reference_num_id_seq` - Created automatically in 2025 when column `num_id` was modified to become an `IDENTITY` column.

The result is new inserts to `references` table e.g., when ingesting new data, would fail with the error ` ERROR: more than one owned sequence found`.

The changes add a migration that ensures that the older manually created sequence `reference_id_seq`.

Moreover, in the migration `uploaded-dataset-ingestion-tracking-fields` we modify the column creations and deletions so that they only take place when the column does not or does exist otherwise new migrations would fail.