### PR TITLE
fix/update-node-version

### DIFF
--- a/.github/workflows/api-pr-build.yml
+++ b/.github/workflows/api-pr-build.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: src/API
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -76,7 +76,7 @@ jobs:
         working-directory: src/API
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Update node version used for API GitHub workflows to version 22. Package that caused the issue is the '@azure/logger@1.4.0'.
