### PR TITLE
fix/ensure-country-id-is-escaped

### DIFF
--- a/src/IngestionAPI/lib.py
+++ b/src/IngestionAPI/lib.py
@@ -1583,7 +1583,7 @@ def load_site_data(conn, data_row) -> str:
         else:
             # Try update the value of country_id
             query = template_update_site_data_country.format(
-                country_id=country_id,
+                country_id=get_string_val(country_id),
                 id=_record_exist,
             )
             run_query(conn=conn, query=query)


### PR DESCRIPTION
Fix eliminates postgres' syntax error due to malformed escaping when country contains special symbols like `'`